### PR TITLE
make app functional but self documenting

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -37,7 +37,7 @@
 
     <div class="instructions">
       <details>
-        <summary>Instructions</summary>
+        <summary>Instructions <span data-help="instructions-summary-title" class="helpicon"></span></summary>
         <ul>
           <li>[Reset Table] To clear all table data</li>
           <li>Expand '&gt; Instructions' to read the instructions</li>
@@ -67,6 +67,7 @@
           <li>Adding a number of rows to generate and clicking [Generate] button</li>
           <li>Rule can be a RegEx expression or a faker API call e.g. (Connie|Bob) or faker.name.firstName</li>
         </ul>
+        <button type="button" class="instructions-copy-to-grid-button">Copy Instructions To Grid</button>
         <div class="footer">
           <p>
             v20220801.001 Built by

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
@@ -47,10 +47,11 @@ test('add row button creates row in grid', async ({ page }) => {
   await appPage.gridEditor.addRow();
   await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(initialRowCount + 1);
   const rowCountAfterAdd = await appPage.gridEditor.renderer.countRows();
+  const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
 
   const lastRowIndex = rowCountAfterAdd - 1;
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getCellTextByColumnName('Instructions', lastRowIndex))
+    .poll(async () => appPage.gridEditor.renderer.getCellTextByColumnName(primaryColumnName, lastRowIndex))
     .toBe('');
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
@@ -24,6 +24,8 @@ test('add rows above and below increase row count', async ({ page }) => {
   const appPage = new AppPage(page);
 
   await appPage.goto();
+  await appPage.gridEditor.addRow();
+  await appPage.gridEditor.addRow();
   const initialRows = await appPage.gridEditor.renderer.countRows();
 
   await appPage.gridEditor.renderer.selectRow(1);
@@ -55,9 +57,15 @@ test('quick filter and clear filters update visible rows', async ({ page }) => {
   const appPage = new AppPage(page);
 
   await appPage.goto();
+  await appPage.gridEditor.addRow();
+  await appPage.gridEditor.addRow();
+  await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(2);
+  const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
+  await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 0, 'Filter Match');
+  await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 1, 'Different Value');
   const totalRows = await appPage.gridEditor.renderer.countRows();
 
-  await appPage.gridEditor.filterBy('Rename Column');
+  await appPage.gridEditor.filterBy('Filter Match');
   await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBeLessThan(totalRows);
 
   await appPage.gridEditor.clearFilters();

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -33,7 +33,7 @@ class GridEditorComponent {
 
   async expectReady() {
     await this.expectVisible();
-    await this.renderer.waitForColumnName('Instructions');
+    await this.grid.locator('.tabulator-col-title').first().waitFor({ state: 'visible' });
   }
 
   async addRow() {

--- a/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
@@ -73,11 +73,11 @@ class GridHeaderComponent {
   }
 
   async sortAsc(columnName) {
-    await this.clickAction(columnName, 'sort-asc');
+    await this._ensureSortState(columnName, 'asc', 'sort-asc');
   }
 
   async sortDesc(columnName) {
-    await this.clickAction(columnName, 'sort-desc');
+    await this._ensureSortState(columnName, 'desc', 'sort-desc');
   }
 
   async clearSort(columnName) {
@@ -102,6 +102,20 @@ class GridHeaderComponent {
       .locator(`xpath=ancestor::*[contains(@class,'tabulator-col')]`)
       .first();
     return (await header.getAttribute('aria-sort')) || '';
+  }
+
+  async _ensureSortState(columnName, expectedState, action) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await this.clickAction(columnName, action);
+      for (let check = 0; check < 10; check += 1) {
+        const state = await this.getColumnSortState(columnName);
+        if (String(state).includes(expectedState)) {
+          return;
+        }
+        await this.page.waitForTimeout(50);
+      }
+    }
+    throw new Error(`Failed to set sort state '${expectedState}' for column '${columnName}'.`);
   }
 
   _headerTitleByName(columnName) {

--- a/apps/web/src/tests/jest/script-bootstrap.test.js
+++ b/apps/web/src/tests/jest/script-bootstrap.test.js
@@ -71,7 +71,6 @@ describe('script bootstrap', () => {
       ExporterClass,
       ImporterClass,
       enableTestDataGenerationInterfaceFn: () => {},
-      scheduleInitialInstructions: false,
     });
 
     expect(calls[0]).toBe('ensureGridLibraryLoaded');
@@ -102,15 +101,13 @@ describe('script bootstrap', () => {
       ExporterClass: class {},
       ImporterClass: class {},
       enableTestDataGenerationInterfaceFn: () => {},
-      scheduleInitialInstructions: false,
     });
 
     expect(calls).toEqual([]);
     expect(consoleSpy).toHaveBeenCalled();
   });
 
-  test('wires controller, test data integration, and schedules initial instructions by default', async () => {
-    const setTimeoutFn = jest.fn();
+  test('wires controller and test data integration without scheduling instructions import', async () => {
     const enableTestDataGenerationInterfaceFn = jest.fn();
     const gridExtras = {
       clearGrid: jest.fn(),
@@ -176,7 +173,6 @@ describe('script bootstrap', () => {
       ExporterClass,
       ImporterClass,
       enableTestDataGenerationInterfaceFn,
-      setTimeoutFn,
     });
 
     expect(addHTMLtoGui).toHaveBeenCalledWith(dom.window.document.getElementById('import-export-controls'));
@@ -197,21 +193,17 @@ describe('script bootstrap', () => {
       expect.any(ImportExportControlsClass),
       gridExtras
     );
-    expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 3000);
   });
 
-  test('scheduled instructions callback clears grid, imports instructions, and sizes columns', async () => {
+  test('instructions tooltip sample button loads sample data table', async () => {
     const clearGrid = jest.fn();
     const sizeColumnsToFit = jest.fn();
-    const setGridFromGenericDataTable = jest.fn();
-    let scheduledCallback;
 
     class ExtendedDataGridClass {
       createChildGrid() {}
       getGridExtras() {
         return {
           clearGrid,
-          setGridFromGenericDataTable,
           getGridAsGenericDataTable: jest.fn(() => ({ getHeaders: () => [] })),
           getHeadersFromGrid: jest.fn(() => []),
         };
@@ -250,12 +242,74 @@ describe('script bootstrap', () => {
       ExporterClass: class {},
       ImporterClass,
       enableTestDataGenerationInterfaceFn: () => {},
-      setTimeoutFn: (callback) => {
-        scheduledCallback = callback;
-      },
     });
 
-    scheduledCallback();
+    const button = dom.window.document.createElement('button');
+    button.className = 'instructions-sample-data-button';
+    dom.window.document.body.appendChild(button);
+    button.click();
+
+    expect(clearGrid).toHaveBeenCalledTimes(1);
+    expect(importerInstance.setGridFromGenericDataTable).toHaveBeenCalledTimes(1);
+    const dataTable = importerInstance.setGridFromGenericDataTable.mock.calls[0][0];
+    expect(dataTable.getHeaders()).toEqual(['First Name', 'Last Name', 'Department', 'Role', 'Status']);
+    expect(dataTable.getRowCount()).toBe(4);
+    expect(sizeColumnsToFit).toHaveBeenCalledTimes(1);
+  });
+
+  test('instructions details button copies instructions list into grid', async () => {
+    const clearGrid = jest.fn();
+    const sizeColumnsToFit = jest.fn();
+
+    class ExtendedDataGridClass {
+      createChildGrid() {}
+      getGridExtras() {
+        return {
+          clearGrid,
+          getGridAsGenericDataTable: jest.fn(() => ({ getHeaders: () => [] })),
+          getHeadersFromGrid: jest.fn(() => []),
+        };
+      }
+      sizeColumnsToFit() {
+        sizeColumnsToFit();
+      }
+    }
+
+    class ImportExportControlsClass {
+      addHTMLtoGui() {}
+      setExporter() {}
+      setImporter() {}
+      renderTextFromGrid() {}
+      setFileFormatType() {}
+      setOptionsViewForFormatType() {}
+    }
+
+    let importerInstance;
+    class ImporterClass {
+      constructor() {
+        importerInstance = this;
+      }
+      setGridFromGenericDataTable = jest.fn();
+    }
+
+    await bootstrapApp({
+      documentObj: dom.window.document,
+      ensureGridLibraryLoadedFn: jest.fn(() => Promise.resolve()),
+      activeGridEngineName: 'tabulator',
+      ExtendedDataGridClass,
+      ImportExportControlsClass,
+      TabbedTextControlClass: class {
+        addToGui() {}
+      },
+      ExporterClass: class {},
+      ImporterClass,
+      enableTestDataGenerationInterfaceFn: () => {},
+    });
+
+    const button = dom.window.document.createElement('button');
+    button.className = 'instructions-copy-to-grid-button';
+    dom.window.document.body.appendChild(button);
+    button.click();
 
     expect(clearGrid).toHaveBeenCalledTimes(1);
     expect(importerInstance.setGridFromGenericDataTable).toHaveBeenCalledTimes(1);

--- a/apps/web/src/tests/jest/script-module-init.test.js
+++ b/apps/web/src/tests/jest/script-module-init.test.js
@@ -126,7 +126,7 @@ describe('script module initialization', () => {
       expect.any(Object),
       gridExtras
     );
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 3000);
+    expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 3000);
 
     dom.window.close();
   });

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -393,6 +393,14 @@ Custom header styles for default items
   color: #afdfff;
 }
 
+.instructions-sample-data-button {
+  margin-top: 0.4rem;
+}
+
+.instructions-copy-to-grid-button {
+  margin-top: 0.4rem;
+}
+
 .import-progress-status {
   margin-top: 0.45rem;
   padding: 0.2rem 0.5rem;

--- a/packages/core-ui/js/gui_components/tabbed-text-control.js
+++ b/packages/core-ui/js/gui_components/tabbed-text-control.js
@@ -45,6 +45,8 @@ class TabbedTextControl {
       { id: 'html', label: 'HTML', type: 'html' },
       { id: 'asciitable', label: 'ASCII', type: 'asciitable' },
     ];
+    this.editModeHelpText =
+      'Edit mode shows the full grid text in the chosen format. You can edit this text and use Set Grid From Text to apply changes back into the grid.';
   }
 
   // TODO : populate this from the registered importers and exporters rather than hard coding
@@ -57,6 +59,12 @@ class TabbedTextControl {
             </ul>
           </div>
           <div class="rightbuttons">
+            <span
+              title="Preview/Edit mode help"
+              id="previewEditModeHelpIcon"
+              data-help="preview-edit-mode-help"
+              class="helpicon option-help-icon"
+            ></span>
             <button title="Toggle Preview/Edit mode" id="previewEditModeButton">Preview</button>
             <button title="Copy text to clipboard" id="copyTextButton">Copy</button>
           </div>
@@ -268,6 +276,7 @@ class TabbedTextControl {
 
   _syncPreviewEditButtonLabel() {
     const modeButton = this.parent.querySelector('#previewEditModeButton');
+    const modeHelpIcon = this.parent.querySelector('#previewEditModeHelpIcon');
     if (!modeButton) {
       return;
     }
@@ -275,9 +284,18 @@ class TabbedTextControl {
     if (this.importExportController?.isPreviewTextMode?.()) {
       const rowLimit = this.importExportController?.getPreviewRowLimit?.() ?? 10;
       modeButton.innerText = `Preview (${rowLimit})`;
+      if (modeHelpIcon) {
+        const previewHelpText = `Preview mode shows a sample of the first ${rowLimit} rows from the data grid in the chosen format. Click Preview to switch to Edit mode and show full grid data.`;
+        modeHelpIcon.setAttribute('data-help-text', previewHelpText);
+        modeHelpIcon._tippy?.setContent?.(previewHelpText);
+      }
       return;
     }
     modeButton.innerText = 'Edit';
+    if (modeHelpIcon) {
+      modeHelpIcon.setAttribute('data-help-text', this.editModeHelpText);
+      modeHelpIcon._tippy?.setContent?.(this.editModeHelpText);
+    }
   }
 }
 

--- a/packages/core-ui/js/gui_components/testdatadefn.js
+++ b/packages/core-ui/js/gui_components/testdatadefn.js
@@ -38,6 +38,7 @@ let textPreviewRenderer = undefined;
 let mainGridExtras = undefined;
 let testDataStatusResetTimeoutId = null;
 let activeDefnCellEdit = null;
+let schemaSampleButtonClickHandler = null;
 
 function getRulesParserFromTextArea() {
   // faker imported in script.js
@@ -395,6 +396,24 @@ function yieldToUi() {
     }
     requestAnimationFrame(() => setTimeout(resolve, 0));
   });
+}
+
+function loadSampleSchemaIntoTextArea() {
+  const schemaTextArea = document.getElementById('testdatadefntext');
+  if (!schemaTextArea) {
+    return;
+  }
+
+  schemaTextArea.value = `Literal Example
+Pending Review
+Enum Example
+enum("Open","In Progress","Closed")
+Regex Example
+[A-Z]{3}-\\d{4}
+Faker Example
+person.fullName`;
+
+  schemaTextArea.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
 function createTestDataGrid() {
@@ -794,7 +813,13 @@ function enableTestDataGenerationInterface(parentId, anImporter, aTextPreviewRen
             <div class="defn-grid-container" id="defngrid" class="ag-theme-alpine">
             </div>
             <div class="defn-text-container">
-                <p>Test Data Text Schema</p>
+                <p>
+                  Test Data Text Schema
+                  <span
+                    data-help="test-data-text-schema-help"
+                    class="helpicon option-help-icon"
+                  ></span>
+                </p>
                 <textarea class="testDataDefn" name="testdatadefntext" id="testdatadefntext"></textarea>
             </div>
         </div>
@@ -804,7 +829,6 @@ function enableTestDataGenerationInterface(parentId, anImporter, aTextPreviewRen
   element.addEventListener('click', generateTestData, false);
   document.querySelector('#generateallpairs').addEventListener('click', generatePairwiseTestData, false);
   document.querySelector('#refreshtestdatapreview').addEventListener('click', refreshTestDataPreview, false);
-
   const generateCountInput = document.getElementById('generateCount');
   generateCountInput.value = '1';
 
@@ -830,6 +854,23 @@ function enableTestDataGenerationInterface(parentId, anImporter, aTextPreviewRen
     },
     false
   );
+
+  if (schemaSampleButtonClickHandler) {
+    document.removeEventListener('click', schemaSampleButtonClickHandler);
+  }
+  schemaSampleButtonClickHandler = (event) => {
+    if (!event.target.closest('.testdata-schema-sample-button')) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    loadSampleSchemaIntoTextArea();
+  };
+  document.addEventListener('click', schemaSampleButtonClickHandler);
+
+  if (typeof window !== 'undefined' && typeof window.updateHelpHints === 'function') {
+    window.updateHelpHints();
+  }
 }
 
 export { enableTestDataGenerationInterface, probeCommandReturnType, identifyFakerCommands, getFakerCommands };

--- a/packages/core-ui/js/gui_components/testdatadefn.js
+++ b/packages/core-ui/js/gui_components/testdatadefn.js
@@ -44,7 +44,13 @@ function getRulesParserFromTextArea() {
   // faker imported in script.js
   // RandExp brought in via index.html script
   const generator = new TestDataGenerator(faker, RandExp);
-  const areaText = document.getElementById('testdatadefntext').value;
+  const schemaTextArea = document.getElementById('testdatadefntext');
+  if (!schemaTextArea) {
+    generator.importSpec('');
+    generator.compile();
+    return generator;
+  }
+  const areaText = schemaTextArea.value;
   generator.importSpec(areaText);
   generator.compile();
   console.log(generator.compilationReport());
@@ -412,8 +418,7 @@ Regex Example
 [A-Z]{3}-\\d{4}
 Faker Example
 person.fullName`;
-
-  schemaTextArea.dispatchEvent(new Event('input', { bubbles: true }));
+  populateTestDataGridFromRules();
 }
 
 function createTestDataGrid() {

--- a/packages/core-ui/js/help/inline-help-content.js
+++ b/packages/core-ui/js/help/inline-help-content.js
@@ -116,6 +116,29 @@ const sharedInlineHelpEntries = {
 };
 
 const appOnlyInlineHelpEntries = {
+  'test-data-text-schema-help': `
+      <p>Define schema as repeating line pairs:</p>
+      <ul>
+        <li>Line 1: column header name</li>
+        <li>Line 2: data definition</li>
+      </ul>
+      <p>Definition types:</p>
+      <ul>
+        <li><strong>Literal</strong>: fixed text value for every generated row.</li>
+        <li><strong>Enum</strong>: choose from listed values, e.g. <code>enum("Open","In Progress","Closed")</code>.</li>
+        <li><strong>RegEx</strong>: generate values from a regex pattern, e.g. <code>[A-Z]{3}-\\d{4}</code>.</li>
+        <li><strong>Faker</strong>: realistic random values, e.g. <code>person.fullName</code>.</li>
+      </ul>
+      <button type="button" class="testdata-schema-sample-button">Load Sample Schema</button>
+    `,
+  'instructions-summary-title': `
+      <p>This app converts table data between formats, and lets you edit directly in the grid.</p>
+      <ul>
+        <li>Use import/export controls to switch between text formats and grid data.</li>
+        <li>Use column and row controls directly in the grid to shape your table.</li>
+      </ul>
+      <button type="button" class="instructions-sample-data-button">Load Sample Data</button>
+    `,
   'test-data-summary-title': `
       <p>The Test Data section allows you to randomly generate data to populate the grid. You can then export to the various supported formats.</p>
       <p><a class="helplink" href="/docs/test-data/test-data-generation" target="anywaydatadocs">Learn more</a></p>

--- a/packages/core-ui/js/script.js
+++ b/packages/core-ui/js/script.js
@@ -11,6 +11,7 @@ import { initHelpTooltips } from './help/help-tooltips.js';
 var importer, exporter;
 var mainDataGrid;
 var importExportController;
+var instructionsSampleButtonClickHandler;
 
 async function bootstrapApp({
   documentObj = document,
@@ -22,8 +23,6 @@ async function bootstrapApp({
   ExporterClass = Exporter,
   ImporterClass = Importer,
   enableTestDataGenerationInterfaceFn = enableTestDataGenerationInterface,
-  scheduleInitialInstructions = true,
-  setTimeoutFn = setTimeout,
 } = {}) {
   console.log(`Using grid engine: ${activeGridEngineName}`);
   try {
@@ -47,15 +46,11 @@ async function bootstrapApp({
   importExportController.setExporter(exporter);
   importExportController.setImporter(importer);
 
-  // give a clue what to do by importing the instructions into the grid
-  if (scheduleInitialInstructions) {
-    setTimeoutFn(setTextFromInstructions, 3000);
-  }
-
   importExportController.renderTextFromGrid();
   importExportController.setFileFormatType();
   importExportController.setOptionsViewForFormatType();
   initHelpTooltips({ documentObj, includeAppOnlyEntries: true });
+  wireInstructionsSampleButton(documentObj);
 
   const loadingMessage = documentObj.getElementById('initial-load');
   if (loadingMessage) {
@@ -83,18 +78,68 @@ if (typeof document !== 'undefined') {
   }
 }
 
-function setTextFromInstructions() {
-  console.log('Setting Grid Instructions');
+function setSampleGridData() {
+  if (!mainDataGrid || !importer) {
+    return;
+  }
+
+  const sampleData = new GenericDataTable();
+  sampleData.addHeader('First Name');
+  sampleData.addHeader('Last Name');
+  sampleData.addHeader('Department');
+  sampleData.addHeader('Role');
+  sampleData.addHeader('Status');
+
+  sampleData.appendDataRow(['Ava', 'Nguyen', 'Engineering', 'QA Engineer', 'Active']);
+  sampleData.appendDataRow(['Liam', 'Patel', 'Sales', 'Account Executive', 'Onboarding']);
+  sampleData.appendDataRow(['Noah', 'Carter', 'Finance', 'Analyst', 'Active']);
+  sampleData.appendDataRow(['Mia', 'Roberts', 'Support', 'Team Lead', 'On Leave']);
+
   mainDataGrid.getGridExtras().clearGrid();
-  const instructions = document.querySelectorAll('div.instructions details ul li');
-  let textData = new GenericDataTable();
-  textData.addHeader('Instructions');
-  instructions.forEach((instruction) => {
-    textData.appendDataRow([instruction.textContent]);
-  });
-  importer.setGridFromGenericDataTable(textData);
-  // set the instructions to fit grid size
+  importer.setGridFromGenericDataTable(sampleData);
   mainDataGrid.sizeColumnsToFit();
+}
+
+function setInstructionsGridData(documentObj = document) {
+  if (!mainDataGrid || !importer) {
+    return;
+  }
+
+  const instructions = documentObj.querySelectorAll('div.instructions details ul li');
+  const instructionsData = new GenericDataTable();
+  instructionsData.addHeader('Instructions');
+
+  instructions.forEach((instruction) => {
+    instructionsData.appendDataRow([instruction.textContent]);
+  });
+
+  mainDataGrid.getGridExtras().clearGrid();
+  importer.setGridFromGenericDataTable(instructionsData);
+  mainDataGrid.sizeColumnsToFit();
+}
+
+function wireInstructionsSampleButton(documentObj = document) {
+  if (instructionsSampleButtonClickHandler) {
+    documentObj.removeEventListener('click', instructionsSampleButtonClickHandler);
+  }
+
+  const handleInstructionsSampleButtonClick = (event) => {
+    if (event.target.closest('.instructions-sample-data-button')) {
+      event.preventDefault();
+      event.stopPropagation();
+      setSampleGridData();
+      return;
+    }
+
+    if (event.target.closest('.instructions-copy-to-grid-button')) {
+      event.preventDefault();
+      event.stopPropagation();
+      setInstructionsGridData(documentObj);
+    }
+  };
+
+  instructionsSampleButtonClickHandler = handleInstructionsSampleButtonClick;
+  documentObj.addEventListener('click', instructionsSampleButtonClickHandler);
 }
 
 export { bootstrapApp };

--- a/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
+++ b/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
@@ -399,4 +399,39 @@ describe('test data definition editor engine compatibility', () => {
 
     delete global.Tabulator;
   });
+
+  test('load sample schema button populates text schema with literal, enum, regex, and faker examples', () => {
+    installTabulatorMock();
+
+    enableTestDataGenerationInterface(
+      'host',
+      {
+        setGridFromGenericDataTable: jest.fn(),
+      },
+      {
+        renderTextFromGrid: jest.fn(),
+      },
+      {
+        getRowCount: jest.fn(() => 0),
+        getSelectedRowIndexes: jest.fn(() => []),
+      }
+    );
+
+    const tooltipButton = document.createElement('button');
+    tooltipButton.className = 'testdata-schema-sample-button';
+    document.body.appendChild(tooltipButton);
+    tooltipButton.click();
+    const value = document.getElementById('testdatadefntext').value;
+
+    expect(value).toContain('Literal Example');
+    expect(value).toContain('Pending Review');
+    expect(value).toContain('Enum Example');
+    expect(value).toContain('enum("Open","In Progress","Closed")');
+    expect(value).toContain('Regex Example');
+    expect(value).toContain('[A-Z]{3}-\\d{4}');
+    expect(value).toContain('Faker Example');
+    expect(value).toContain('person.fullName');
+
+    delete global.Tabulator;
+  });
 });

--- a/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
+++ b/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
@@ -32,10 +32,19 @@ describe('TabbedTextControl preview/edit button', () => {
     tabs.addToGui();
 
     const modeButton = host.querySelector('#previewEditModeButton');
+    const modeHelpIcon = host.querySelector('#previewEditModeHelpIcon');
+    modeHelpIcon._tippy = { setContent: jest.fn() };
+    tabs._syncPreviewEditButtonLabel();
     expect(modeButton.innerText).toBe('Preview (10)');
+    expect(modeHelpIcon.getAttribute('data-help-text')).toContain('sample of the first 10 rows');
+    expect(modeHelpIcon.getAttribute('data-help-text')).toContain('switch to Edit mode');
+    expect(modeHelpIcon._tippy.setContent).toHaveBeenCalledWith(expect.stringContaining('sample of the first 10 rows'));
 
     modeButton.click();
     expect(modeButton.innerText).toBe('Edit');
+    expect(modeHelpIcon.getAttribute('data-help-text')).toContain('full grid text');
+    expect(modeHelpIcon.getAttribute('data-help-text')).toContain('Set Grid From Text');
+    expect(modeHelpIcon._tippy.setContent).toHaveBeenLastCalledWith(expect.stringContaining('full grid text'));
   });
 
   test('selecting Code defaults to C# subtask and exposes language code subtasks', () => {

--- a/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
+++ b/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
@@ -33,6 +33,7 @@ describe('TabbedTextControl preview/edit button', () => {
 
     const modeButton = host.querySelector('#previewEditModeButton');
     const modeHelpIcon = host.querySelector('#previewEditModeHelpIcon');
+    expect(modeHelpIcon).not.toBeNull();
     modeHelpIcon._tippy = { setContent: jest.fn() };
     tabs._syncPreviewEditButtonLabel();
     expect(modeButton.innerText).toBe('Preview (10)');


### PR DESCRIPTION
closes #59 
also improved self documeting of app.html by
adding add instructions button - instead of auto load
adding tippy on preview/edit
adding tippy on test data schema (with option to load a default example)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy Instructions To Grid" and "Load Sample Data" buttons; help icons and richer inline help added to instruction and schema panels; "Load Sample Schema" populates the schema editor.

* **Change**
  * Initial instructions no longer auto-load on startup — loading is now explicit via the new buttons.

* **Styles**
  * Added spacing for the new instruction buttons.

* **Tests**
  * Added and updated UI tests covering the new buttons and help-tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->