### PR TITLE
added pairwise to cli, api and mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,15 @@ Supported options:
 
 - `-i, --inputfile` path to the input text spec (required)
 - `-n, --numberOfLines` number of rows to generate (default `1`)
+- `--pairwise` generate pairwise combinations for enum fields (requires at least 2 enum rules)
 - `-f, --format` output format (default `csv`)
 - `-o, --outputfile` write output to file instead of stdout
 - `-t, --testMode` enable diagnostics mode and generate one row
 - `--unsafe-faker-expressions` allow expression-style faker args (disabled by default)
+
+Pairwise note:
+
+- when `--pairwise` is enabled, `--numberOfLines` is accepted but ignored (the pairwise engine determines row count)
 
 ## REST API Quick Start
 
@@ -295,7 +300,8 @@ Raw multiline schema/spec endpoint:
 
 - `Content-Type` must be `text/plain`
 - request body is the full multiline spec
-- query params: `rowCount` (required), `outputFormat` (optional), `seed` (optional), `responseFormat` (optional: `rows|rendered|all|raw`)
+- query params: `rowCount` (required), `outputFormat` (optional), `seed` (optional), `pairwise` (optional), `responseFormat` (optional: `rows|rendered|all|raw`)
+- pairwise note: when `pairwise=true`, `rowCount` is accepted for compatibility but ignored (pairwise output size is computed automatically)
 
 Set format default options:
 
@@ -411,6 +417,7 @@ Inputs:
 
 - `textSpec` (required string)
 - `rowCount` (required integer, >= 0)
+- `pairwise` (optional boolean, default `false`; when `true`, `rowCount` is ignored)
 - `outputFormat` (required string e.g. `csv`, `json`, `jsonl`, `xml`, `sql`)
 - `options` (optional object)
 - `seed` (optional number)

--- a/apps/api/src/fromschema.route.test.js
+++ b/apps/api/src/fromschema.route.test.js
@@ -156,3 +156,23 @@ test('/v1/generate/fromschema applies unit-test defaults for includeSetup', asyn
     expect(resetDefaults.status).toBe(200);
   }
 });
+
+test('/v1/generate/fromschema supports pairwise query flag', async () => {
+  const response = await fetch(url('/v1/generate/fromschema?rowCount=50&pairwise=true&outputFormat=json'), {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain' },
+    body: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark',
+  });
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.headers).toEqual(['Browser', 'Theme']);
+  expect(body.rows).toEqual([
+    ['Chrome', 'Light'],
+    ['Chrome', 'Dark'],
+    ['Firefox', 'Light'],
+    ['Firefox', 'Dark'],
+    ['Safari', 'Light'],
+    ['Safari', 'Dark'],
+  ]);
+});

--- a/apps/api/src/generate.route.test.js
+++ b/apps/api/src/generate.route.test.js
@@ -135,3 +135,54 @@ test('/v1/generate parity: REST rendered matches core for all unit-test framewor
     expect(body.rendered).toBe(coreResult.rendered);
   }
 });
+
+test('/v1/generate supports pairwise mode', async () => {
+  const response = await fetch(url('/v1/generate'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark',
+      rowCount: 99,
+      outputFormat: 'json',
+      pairwise: true,
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.headers).toEqual(['Browser', 'Theme']);
+  expect(body.rows).toEqual([
+    ['Chrome', 'Light'],
+    ['Chrome', 'Dark'],
+    ['Firefox', 'Light'],
+    ['Firefox', 'Dark'],
+    ['Safari', 'Light'],
+    ['Safari', 'Dark'],
+  ]);
+});
+
+test('/v1/generate supports pairwise for x-www-form-urlencoded payloads', async () => {
+  const form = new URLSearchParams();
+  form.set('textSpec', 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark');
+  form.set('rowCount', '99');
+  form.set('outputFormat', 'json');
+  form.set('pairwise', 'true');
+
+  const response = await fetch(url('/v1/generate'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.headers).toEqual(['Browser', 'Theme']);
+  expect(body.rows).toEqual([
+    ['Chrome', 'Light'],
+    ['Chrome', 'Dark'],
+    ['Firefox', 'Light'],
+    ['Firefox', 'Dark'],
+    ['Safari', 'Light'],
+    ['Safari', 'Dark'],
+  ]);
+});

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -361,7 +361,7 @@ function resetDefaultOptionsForFormat(format) {
 }
 
 function runGeneration(payload = {}) {
-  const { textSpec, rowCount, outputFormat = 'csv', options, seed, unsafeFakerExpressions } = payload;
+  const { textSpec, rowCount, outputFormat = 'csv', options, seed, pairwise, unsafeFakerExpressions } = payload;
   const concreteOutputFormat = String(outputFormat || 'csv').toLowerCase();
 
   if (!SUPPORTED_FORMATS.includes(String(outputFormat).toLowerCase())) {
@@ -403,6 +403,7 @@ function runGeneration(payload = {}) {
       outputFormat: concreteOutputFormat,
       options: effectiveOptions,
       seed: parsedSeed.seed,
+      pairwise: parseBooleanFlag(pairwise),
       unsafeFakerExpressions: unsafeFakerExpressions || false,
     });
     if (!result?.ok) {
@@ -494,6 +495,7 @@ function buildFromSchemaPayload(req) {
     rowCount,
     outputFormat: outputFormat || 'csv',
     seed,
+    pairwise: req.query?.pairwise === 'true',
     responseFormat,
     unsafeFakerExpressions: unsafeFakerExpressions === 'true',
   };

--- a/apps/api/src/openapi.js
+++ b/apps/api/src/openapi.js
@@ -41,7 +41,11 @@ const openApiDocument = {
                 required: ['textSpec', 'rowCount'],
                 properties: {
                   textSpec: { type: 'string' },
-                  rowCount: { type: 'integer', minimum: 0 },
+                  rowCount: {
+                    type: 'integer',
+                    minimum: 0,
+                    description: 'Requested row count. Ignored when pairwise is true.',
+                  },
                   outputFormat: {
                     type: 'string',
                     enum: [
@@ -106,7 +110,11 @@ const openApiDocument = {
                 required: ['textSpec', 'rowCount'],
                 properties: {
                   textSpec: { type: 'string' },
-                  rowCount: { type: 'integer', minimum: 0 },
+                  rowCount: {
+                    type: 'integer',
+                    minimum: 0,
+                    description: 'Requested row count. Ignored when pairwise is true.',
+                  },
                   outputFormat: {
                     type: 'string',
                     enum: [
@@ -233,7 +241,7 @@ const openApiDocument = {
             name: 'rowCount',
             required: true,
             schema: { type: 'integer', minimum: 0 },
-            description: 'Number of rows to generate',
+            description: 'Number of rows to generate. Ignored when pairwise=true.',
           },
           {
             in: 'query',
@@ -296,7 +304,8 @@ const openApiDocument = {
               type: 'boolean',
               default: false,
             },
-            description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
+            description:
+              'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules). When true, rowCount is ignored.',
           },
           {
             in: 'query',

--- a/apps/api/src/openapi.js
+++ b/apps/api/src/openapi.js
@@ -86,6 +86,11 @@ const openApiDocument = {
                   },
                   options: { type: 'object' },
                   seed: { type: 'number' },
+                  pairwise: {
+                    type: 'boolean',
+                    default: false,
+                    description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
+                  },
                   unsafeFakerExpressions: {
                     type: 'boolean',
                     default: false,
@@ -145,6 +150,11 @@ const openApiDocument = {
                     default: 'csv',
                   },
                   seed: { type: 'number' },
+                  pairwise: {
+                    type: 'boolean',
+                    default: false,
+                    description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
+                  },
                   unsafeFakerExpressions: {
                     type: 'boolean',
                     default: false,
@@ -277,6 +287,16 @@ const openApiDocument = {
             name: 'seed',
             required: false,
             schema: { type: 'number' },
+          },
+          {
+            in: 'query',
+            name: 'pairwise',
+            required: false,
+            schema: {
+              type: 'boolean',
+              default: false,
+            },
+            description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
           },
           {
             in: 'query',

--- a/apps/cli/src/cli-options.js
+++ b/apps/cli/src/cli-options.js
@@ -47,6 +47,11 @@ export function parseCliOptions(argvInput = process.argv) {
       default: false,
       describe: 'Allow expression-style faker arguments (unsafe for untrusted input)',
     })
+    .option('pairwise', {
+      type: 'boolean',
+      default: false,
+      describe: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules)',
+    })
     .help('h')
     .alias('h', 'help')
     .parseSync();
@@ -66,5 +71,6 @@ export function parseCliOptions(argvInput = process.argv) {
     showProgress,
     shouldStream,
     unsafeFakerExpressions: parsed['unsafe-faker-expressions'] === true,
+    pairwise: parsed.pairwise === true,
   };
 }

--- a/apps/cli/src/run-cli.js
+++ b/apps/cli/src/run-cli.js
@@ -28,8 +28,14 @@ export async function runCliCommand({ options, platform }) {
   if (options.testMode) {
     progress('> Operating in Test Mode - generating 1 entry');
   }
+  const useStreamMode = options.shouldStream && !options.pairwise;
+  if (options.pairwise && options.shouldStream) {
+    if (options.testMode) {
+      progress('WARNING: Streaming is ignored when pairwise generation is enabled; using buffered mode.');
+    }
+  }
 
-  if (options.shouldStream && (options.format === 'csv' || options.format === 'jsonl')) {
+  if (useStreamMode && (options.format === 'csv' || options.format === 'jsonl')) {
     const streamedLines = [];
     const writer = options.outputFile ? platform.createLineWriter(options.outputFile) : null;
     let writerClosed = false;
@@ -38,6 +44,7 @@ export async function runCliCommand({ options, platform }) {
         textSpec,
         rowCount: options.rowCount,
         outputFormat: options.format,
+        pairwise: options.pairwise,
         unsafeFakerExpressions: options.unsafeFakerExpressions,
         onChunk: async (chunk) => {
           if (writer) {
@@ -86,6 +93,7 @@ export async function runCliCommand({ options, platform }) {
     textSpec,
     rowCount: options.rowCount,
     outputFormat: options.format,
+    pairwise: options.pairwise,
     unsafeFakerExpressions: options.unsafeFakerExpressions,
   });
 

--- a/apps/cli/src/run-cli.js
+++ b/apps/cli/src/run-cli.js
@@ -103,6 +103,11 @@ export async function runCliCommand({ options, platform }) {
   }
 
   progress(result.diagnostics.report);
+  if (Array.isArray(result.diagnostics.warnings)) {
+    for (const warning of result.diagnostics.warnings) {
+      progress(`WARNING: ${warning}`);
+    }
+  }
   if (options.testMode && result.rows.length > 0) {
     progress('e.g.');
     progress(JSON.stringify(result.rows[0]));

--- a/apps/cli/src/tests/cli-options.test.js
+++ b/apps/cli/src/tests/cli-options.test.js
@@ -35,3 +35,8 @@ test('stream auto-enabled for large file outputs', () => {
   ]);
   expect(opts.shouldStream).toBe(true);
 });
+
+test('pairwise flag is parsed', () => {
+  const opts = parseCliOptions(['node', 'cli', 'generate', '-i', 'spec.txt', '-n', '5', '--pairwise']);
+  expect(opts.pairwise).toBe(true);
+});

--- a/apps/cli/src/tests/run-cli.test.js
+++ b/apps/cli/src/tests/run-cli.test.js
@@ -50,6 +50,7 @@ test('returns error when input file cannot be read', async () => {
       showProgress: false,
       shouldStream: false,
       unsafeFakerExpressions: false,
+      pairwise: false,
     },
   });
   expect(code).toBe(1);
@@ -69,6 +70,7 @@ test('writes output file in buffered mode', async () => {
       showProgress: false,
       shouldStream: false,
       unsafeFakerExpressions: false,
+      pairwise: false,
     },
   });
   expect(code).toBe(0);
@@ -96,9 +98,81 @@ test('returns error when stream writer fails', async () => {
       showProgress: false,
       shouldStream: true,
       unsafeFakerExpressions: false,
+      pairwise: false,
     },
   });
 
   expect(code).toBe(1);
   expect(platform.err.join('')).toContain('Streaming generation failed');
+});
+
+test('ignores stream mode when pairwise is requested', async () => {
+  const platform = makePlatform({ textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark' });
+  const code = await runCliCommand({
+    platform,
+    options: {
+      inputFile: 'spec.txt',
+      outputFile: 'out.csv',
+      format: 'csv',
+      rowCount: 2,
+      testMode: false,
+      showProgress: false,
+      shouldStream: true,
+      unsafeFakerExpressions: false,
+      pairwise: true,
+    },
+  });
+  expect(code).toBe(0);
+  expect(platform.err.join('')).toBe('');
+  expect(platform.writes.length).toBe(1);
+  expect(platform.writes[0].path).toBe('out.csv');
+});
+
+test('reports warning in test mode when stream mode is ignored for pairwise', async () => {
+  const platform = makePlatform({ textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark' });
+  const code = await runCliCommand({
+    platform,
+    options: {
+      inputFile: 'spec.txt',
+      outputFile: 'out.csv',
+      format: 'csv',
+      rowCount: 2,
+      testMode: true,
+      showProgress: true,
+      shouldStream: true,
+      unsafeFakerExpressions: false,
+      pairwise: true,
+    },
+  });
+  expect(code).toBe(0);
+  expect(platform.out.join('')).toContain('WARNING: Streaming is ignored when pairwise generation is enabled');
+});
+
+test('generates deterministic pairwise output in buffered mode', async () => {
+  const platform = makePlatform({ textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark' });
+  const code = await runCliCommand({
+    platform,
+    options: {
+      inputFile: 'spec.txt',
+      outputFile: null,
+      format: 'json',
+      rowCount: 100,
+      testMode: false,
+      showProgress: false,
+      shouldStream: false,
+      unsafeFakerExpressions: false,
+      pairwise: true,
+    },
+  });
+
+  expect(code).toBe(0);
+  const rendered = platform.out.join('').trim();
+  expect(JSON.parse(rendered)).toEqual([
+    { Browser: 'Chrome', Theme: 'Light' },
+    { Browser: 'Chrome', Theme: 'Dark' },
+    { Browser: 'Firefox', Theme: 'Light' },
+    { Browser: 'Firefox', Theme: 'Dark' },
+    { Browser: 'Safari', Theme: 'Light' },
+    { Browser: 'Safari', Theme: 'Dark' },
+  ]);
 });

--- a/apps/cli/src/tests/run-cli.test.js
+++ b/apps/cli/src/tests/run-cli.test.js
@@ -146,6 +146,7 @@ test('reports warning in test mode when stream mode is ignored for pairwise', as
   });
   expect(code).toBe(0);
   expect(platform.out.join('')).toContain('WARNING: Streaming is ignored when pairwise generation is enabled');
+  expect(platform.out.join('')).toContain('WARNING: rowCount is ignored when pairwise generation is enabled.');
 });
 
 test('generates deterministic pairwise output in buffered mode', async () => {

--- a/apps/mcp/src/index.js
+++ b/apps/mcp/src/index.js
@@ -384,6 +384,10 @@ function handleRequest(request) {
                 outputFormat: { type: 'string', enum: SUPPORTED_FORMATS },
                 options: GENERATE_OPTIONS_SCHEMA,
                 seed: { type: 'number' },
+                pairwise: {
+                  type: 'boolean',
+                  description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
+                },
               },
               required: ['textSpec', 'rowCount', 'outputFormat'],
             },

--- a/apps/mcp/src/mcp.test.js
+++ b/apps/mcp/src/mcp.test.js
@@ -49,6 +49,34 @@ test('MCP server handles generate_data_from_spec tool call', () => {
   expect(response?.result?.structuredContent?.ok).toBe(true);
 });
 
+test('MCP server supports pairwise generation', () => {
+  const response = requestServer({
+    jsonrpc: '2.0',
+    id: 200,
+    method: 'tools/call',
+    params: {
+      name: 'generate_data_from_spec',
+      arguments: {
+        textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark',
+        rowCount: 100,
+        outputFormat: 'json',
+        pairwise: true,
+      },
+    },
+  });
+  const payload = JSON.parse(response?.result?.content?.[0]?.text || '{}');
+  expect(payload.ok).toBe(true);
+  expect(payload.headers).toEqual(['Browser', 'Theme']);
+  expect(payload.rows).toEqual([
+    ['Chrome', 'Light'],
+    ['Chrome', 'Dark'],
+    ['Firefox', 'Light'],
+    ['Firefox', 'Dark'],
+    ['Safari', 'Light'],
+    ['Safari', 'Dark'],
+  ]);
+});
+
 test('MCP server handles test framework output format', () => {
   const response = requestServer({
     jsonrpc: '2.0',

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
@@ -47,7 +47,9 @@ test('add row button creates row in grid', async ({ page }) => {
   await appPage.gridEditor.addRow();
   await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(initialRowCount + 1);
   const rowCountAfterAdd = await appPage.gridEditor.renderer.countRows();
+  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
+  expect(primaryColumnName).toBeTruthy();
 
   const lastRowIndex = rowCountAfterAdd - 1;
   await expect

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
@@ -60,7 +60,9 @@ test('quick filter and clear filters update visible rows', async ({ page }) => {
   await appPage.gridEditor.addRow();
   await appPage.gridEditor.addRow();
   await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(2);
+  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
+  expect(primaryColumnName).toBeTruthy();
   await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 0, 'Filter Match');
   await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 1, 'Different Value');
   const totalRows = await appPage.gridEditor.renderer.countRows();

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -85,7 +85,20 @@ class GridEditorComponent {
   }
 
   async clearFilters() {
-    await this.clearFiltersButton.click();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await this.clearFiltersButton.click();
+      for (let check = 0; check < 20; check += 1) {
+        const quickFilterValue = await this.quickFilterInput.inputValue();
+        const hasActiveColumnFilter = await this.grid
+          .locator('.tabulator-header-filter input')
+          .evaluateAll((inputs) => inputs.some((input) => String(input.value || '').trim().length > 0));
+        if (quickFilterValue === '' && !hasActiveColumnFilter) {
+          return;
+        }
+        await this.page.waitForTimeout(50);
+      }
+    }
+    throw new Error('Failed to clear all filters.');
   }
 
   async clearSort() {

--- a/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
@@ -7,7 +7,9 @@ test('global filter, column filter, sort, and clear filters produce expected vis
   const appPage = new AppPage(page);
   await appPage.goto();
   await seedInstructionsRows(appPage, ['Apple', 'Banana', 'Cherry']);
+  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
+  expect(primaryColumnName).toBeTruthy();
 
   await appPage.gridEditor.setQuickFilter('App');
   await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(1);
@@ -20,6 +22,7 @@ test('global filter, column filter, sort, and clear filters produce expected vis
 
   await appPage.gridEditor.clearFilters();
   await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(3);
+  await expect.poll(async () => appPage.gridEditor.quickFilterInput.inputValue()).toBe('');
   await expect.poll(async () => appPage.gridEditor.header.getColumnFilterValue(primaryColumnName)).toBe('');
 
   await appPage.gridEditor.header.sortAsc(primaryColumnName);

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,6 +4,7 @@ import { TestDataGenerator } from '../js/data_generation/testDataGenerator.js';
 import { GenericDataTable } from '../js/data_formats/generic-data-table.js';
 import { Exporter } from '../js/grid/exporter.js';
 import { KNOWN_FAKER_COMMANDS } from '../js/faker/faker-commands.js';
+import { PairwiseTestDataGenerator } from '../js/data_generation/all-pairs/pairwiseTestDataGenerator.js';
 
 const DEFAULT_FORMAT = 'json';
 const SUPPORTED_FORMATS = [
@@ -162,6 +163,7 @@ export function generateFromTextSpec({
   outputFormat = DEFAULT_FORMAT,
   options = {},
   seed,
+  pairwise = false,
   unsafeFakerExpressions = false,
 } = {}) {
   const errors = [];
@@ -198,9 +200,44 @@ export function generateFromTextSpec({
   }
 
   const dataTable = new GenericDataTable();
-  dataTable.setHeaders(generator.generateHeadersArray());
-  for (let index = 0; index < safeRowCount; index += 1) {
-    dataTable.appendDataRow(generator.generateRow());
+  let effectiveRowCount = safeRowCount;
+
+  if (pairwise) {
+    const pairwiseGenerator = new PairwiseTestDataGenerator(scopedFaker, RandExp);
+    const initResult = pairwiseGenerator.initializeFromRules(generator.testDataRules());
+    if (initResult?.isError) {
+      return {
+        ok: false,
+        errors: [initResult.errorMessage || 'Failed to initialize pairwise generation.'],
+        diagnostics: {
+          report: generator.compilationReport(),
+        },
+      };
+    }
+
+    const rowsResult = pairwiseGenerator.generateAllDataRecordsAsRows();
+    if (rowsResult?.isError) {
+      return {
+        ok: false,
+        errors: [rowsResult.errorMessage || 'Failed to generate pairwise rows.'],
+        diagnostics: {
+          report: generator.compilationReport(),
+        },
+      };
+    }
+
+    const generatedRows = rowsResult?.data?.data || [];
+    const headers = Array.isArray(generatedRows[0]) ? generatedRows[0] : [];
+    dataTable.setHeaders(headers);
+    for (let rowIndex = 1; rowIndex < generatedRows.length; rowIndex += 1) {
+      dataTable.appendDataRow(generatedRows[rowIndex]);
+    }
+    effectiveRowCount = Math.max(generatedRows.length - 1, 0);
+  } else {
+    dataTable.setHeaders(generator.generateHeadersArray());
+    for (let index = 0; index < safeRowCount; index += 1) {
+      dataTable.appendDataRow(generator.generateRow());
+    }
   }
 
   const exporter = createExporter();
@@ -221,7 +258,8 @@ export function generateFromTextSpec({
     format: outputFormat,
     diagnostics: {
       report: generator.compilationReport(),
-      rowCount: safeRowCount,
+      rowCount: effectiveRowCount,
+      pairwise,
     },
   };
 }
@@ -298,6 +336,7 @@ export async function streamFromTextSpec({
   outputFormat = DEFAULT_FORMAT,
   options = {},
   seed,
+  pairwise = false,
   unsafeFakerExpressions = false,
   onChunk,
   collectRows = false,
@@ -319,6 +358,14 @@ export async function streamFromTextSpec({
   });
   if (!validation.ok) {
     return validation;
+  }
+
+  if (pairwise) {
+    return {
+      ok: false,
+      errors: ['Streaming does not support pairwise generation.'],
+      diagnostics: {},
+    };
   }
 
   if (outputFormat !== 'csv' && outputFormat !== 'jsonl') {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -201,8 +201,12 @@ export function generateFromTextSpec({
 
   const dataTable = new GenericDataTable();
   let effectiveRowCount = safeRowCount;
+  const diagnosticsWarnings = [];
 
   if (pairwise) {
+    if (rowCount !== undefined && rowCount !== null) {
+      diagnosticsWarnings.push('rowCount is ignored when pairwise generation is enabled.');
+    }
     const pairwiseGenerator = new PairwiseTestDataGenerator(scopedFaker, RandExp);
     const initResult = pairwiseGenerator.initializeFromRules(generator.testDataRules());
     if (initResult?.isError) {
@@ -227,10 +231,17 @@ export function generateFromTextSpec({
     }
 
     const generatedRows = rowsResult?.data?.data || [];
-    const headers = Array.isArray(generatedRows[0]) ? generatedRows[0] : [];
-    dataTable.setHeaders(headers);
+    const generatedHeaders = Array.isArray(generatedRows[0]) ? generatedRows[0] : [];
+    const originalHeaders = generator.generateHeadersArray();
+    const generatedHeaderIndexes = new Map(generatedHeaders.map((header, index) => [header, index]));
+    dataTable.setHeaders(originalHeaders);
     for (let rowIndex = 1; rowIndex < generatedRows.length; rowIndex += 1) {
-      dataTable.appendDataRow(generatedRows[rowIndex]);
+      const generatedRow = Array.isArray(generatedRows[rowIndex]) ? generatedRows[rowIndex] : [];
+      const reorderedRow = originalHeaders.map((header) => {
+        const generatedIndex = generatedHeaderIndexes.get(header);
+        return generatedIndex === undefined ? '' : generatedRow[generatedIndex];
+      });
+      dataTable.appendDataRow(reorderedRow);
     }
     effectiveRowCount = Math.max(generatedRows.length - 1, 0);
   } else {
@@ -260,6 +271,7 @@ export function generateFromTextSpec({
       report: generator.compilationReport(),
       rowCount: effectiveRowCount,
       pairwise,
+      warnings: diagnosticsWarnings,
     },
   };
 }

--- a/packages/core/src/tests/core-api/generateFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/generateFromTextSpec.test.js
@@ -177,24 +177,47 @@ test('generateFromTextSpec remains deterministic under overlapping seeded invoca
 
 test('generateFromTextSpec supports pairwise generation for enum rules', () => {
   const result = generateFromTextSpec({
-    textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark',
+    textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark\nRegion\nUS,EU',
     rowCount: 100,
     outputFormat: 'json',
     pairwise: true,
   });
 
   expect(result.ok).toBe(true);
-  expect(result.headers).toEqual(['Browser', 'Theme']);
-  expect(result.rows).toEqual([
-    ['Chrome', 'Light'],
-    ['Chrome', 'Dark'],
-    ['Firefox', 'Light'],
-    ['Firefox', 'Dark'],
-    ['Safari', 'Light'],
-    ['Safari', 'Dark'],
-  ]);
+  expect(result.headers).toEqual(['Browser', 'Theme', 'Region']);
+  expect(result.rows.length).toBeLessThan(3 * 2 * 2);
+
+  const valuesByHeader = {
+    Browser: ['Chrome', 'Firefox', 'Safari'],
+    Theme: ['Light', 'Dark'],
+    Region: ['US', 'EU'],
+  };
+  const getValue = (row, header) => row[result.headers.indexOf(header)];
+
+  const coveredPairs = new Set();
+  for (const row of result.rows) {
+    coveredPairs.add(`Browser:${getValue(row, 'Browser')}|Theme:${getValue(row, 'Theme')}`);
+    coveredPairs.add(`Browser:${getValue(row, 'Browser')}|Region:${getValue(row, 'Region')}`);
+    coveredPairs.add(`Theme:${getValue(row, 'Theme')}|Region:${getValue(row, 'Region')}`);
+  }
+
+  for (const browser of valuesByHeader.Browser) {
+    for (const theme of valuesByHeader.Theme) {
+      expect(coveredPairs.has(`Browser:${browser}|Theme:${theme}`)).toBe(true);
+    }
+    for (const region of valuesByHeader.Region) {
+      expect(coveredPairs.has(`Browser:${browser}|Region:${region}`)).toBe(true);
+    }
+  }
+  for (const theme of valuesByHeader.Theme) {
+    for (const region of valuesByHeader.Region) {
+      expect(coveredPairs.has(`Theme:${theme}|Region:${region}`)).toBe(true);
+    }
+  }
+
   expect(result.diagnostics.pairwise).toBe(true);
-  expect(result.diagnostics.rowCount).toBe(6);
+  expect(result.diagnostics.rowCount).toBe(result.rows.length);
+  expect(result.diagnostics.warnings).toContain('rowCount is ignored when pairwise generation is enabled.');
 });
 
 test('generateFromTextSpec rejects pairwise mode with fewer than 2 enum rules', () => {
@@ -207,4 +230,24 @@ test('generateFromTextSpec rejects pairwise mode with fewer than 2 enum rules', 
 
   expect(result.ok).toBe(false);
   expect(result.errors[0]).toMatch(/requires at least 2 ENUM parameters/i);
+});
+
+test('generateFromTextSpec pairwise preserves original interleaved column order', () => {
+  const result = generateFromTextSpec({
+    textSpec: 'Name\nBob\nBrowser\nChrome,Firefox,Safari\nAge\n30\nTheme\nLight,Dark',
+    rowCount: 100,
+    outputFormat: 'json',
+    pairwise: true,
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.headers).toEqual(['Name', 'Browser', 'Age', 'Theme']);
+  expect(result.rows).toEqual([
+    ['Bob', 'Chrome', '30', 'Light'],
+    ['Bob', 'Chrome', '30', 'Dark'],
+    ['Bob', 'Firefox', '30', 'Light'],
+    ['Bob', 'Firefox', '30', 'Dark'],
+    ['Bob', 'Safari', '30', 'Light'],
+    ['Bob', 'Safari', '30', 'Dark'],
+  ]);
 });

--- a/packages/core/src/tests/core-api/generateFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/generateFromTextSpec.test.js
@@ -174,3 +174,37 @@ test('generateFromTextSpec remains deterministic under overlapping seeded invoca
   expect(a.rows).toEqual(aAgain.rows);
   expect(a.rows).not.toEqual(b.rows);
 });
+
+test('generateFromTextSpec supports pairwise generation for enum rules', () => {
+  const result = generateFromTextSpec({
+    textSpec: 'Browser\nChrome,Firefox,Safari\nTheme\nLight,Dark',
+    rowCount: 100,
+    outputFormat: 'json',
+    pairwise: true,
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.headers).toEqual(['Browser', 'Theme']);
+  expect(result.rows).toEqual([
+    ['Chrome', 'Light'],
+    ['Chrome', 'Dark'],
+    ['Firefox', 'Light'],
+    ['Firefox', 'Dark'],
+    ['Safari', 'Light'],
+    ['Safari', 'Dark'],
+  ]);
+  expect(result.diagnostics.pairwise).toBe(true);
+  expect(result.diagnostics.rowCount).toBe(6);
+});
+
+test('generateFromTextSpec rejects pairwise mode with fewer than 2 enum rules', () => {
+  const result = generateFromTextSpec({
+    textSpec: 'OnlyOne\nA,B,C',
+    rowCount: 10,
+    outputFormat: 'json',
+    pairwise: true,
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors[0]).toMatch(/requires at least 2 ENUM parameters/i);
+});

--- a/packages/core/src/tests/core-api/streamFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/streamFromTextSpec.test.js
@@ -45,3 +45,16 @@ test('streamFromTextSpec rejects unsupported formats', async () => {
   expect(result.ok).toBe(false);
   expect(result.errors[0]).toContain('supports only csv and jsonl');
 });
+
+test('streamFromTextSpec rejects pairwise mode', async () => {
+  const result = await streamFromTextSpec({
+    textSpec: 'Browser\nChrome,Firefox\nTheme\nLight,Dark',
+    rowCount: 10,
+    outputFormat: 'csv',
+    pairwise: true,
+    onChunk: async () => {},
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors[0]).toContain('does not support pairwise');
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pairwise combination generation for ENUM fields added across CLI, REST API and MCP tool (new --pairwise / pairwise option).

* **Behavior Changes**
  * Pairwise mode ignores requested row count and disables streaming output (emits warnings when streaming is requested with pairwise).

* **Documentation**
  * README and API docs updated to describe pairwise behavior and caveats.

* **Tests**
  * Extensive pairwise unit/integration tests added and web UI tests made more robust.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eviltester/grid-table-editor/pull/74)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->