### PR TITLE
comments and spaces in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ You can then create a new table, or amend the existing table or selected rows.
 The spec is a paragraph of text where each line is either a 'name' or a 'rule':
 
 ```
+# optional comment
+
 name
 rule
+
+# another comment
 name
 rule
 ```
@@ -102,12 +106,19 @@ The `fake` method is also supported, which takes a mustache template style strin
 So a sample test data spec might look like:
 
 ```
+# person details
 name
 helpers.fake("{{name.lastName}}, {{name.firstName}}")
+
+# profile text
 desc
 faker.lorem.paragraph
+
+# preference data
 collects
 hacker.noun
+
+# regex example
 prefers
 (Connie|Bob)
 ```
@@ -119,10 +130,15 @@ When you have 2 or more enum fields (comma-separated values), you can generate p
 For enum data, use comma-separated values in your spec:
 
 ```
+# pairwise parameters
 browser
 chrome,firefox,safari,edge
+
+# viewport class
 device
 desktop,tablet,mobile
+
+# style variant
 theme
 light,dark
 ```
@@ -337,7 +353,7 @@ Example request body:
 
 ```json
 {
-  "textSpec": "Name\nBob",
+  "textSpec": "# literal example\\n\\nName\\nBob",
   "rowCount": 3,
   "outputFormat": "json"
 }
@@ -368,7 +384,7 @@ Add `unsafeFakerExpressions: true` to individual requests:
 
 ```json
 {
-  "textSpec": "Name\nperson.firstName\nScore\nnumber.int({\"min\": 18, \"max\": 65})",
+  "textSpec": "# faker + numeric range\\n\\nName\\nperson.firstName\\n\\nScore\\nnumber.int({\"min\": 18, \"max\": 65})",
   "rowCount": 5,
   "outputFormat": "json",
   "unsafeFakerExpressions": true

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ You can then create a new table, or amend the existing table or selected rows.
 
 The spec is a paragraph of text where each line is either a 'name' or a 'rule':
 
+### Schema Formatting
+
+- **Comments**: lines starting with `#` (optionally prefixed by whitespace) are treated as comments.
+- **Blank lines**: blank lines are allowed and ignored, so you can separate column groups for readability.
+- **Column definitions**: each column is defined as `name` followed by `rule` on the next logical content line.
+
 ```
 # optional comment
 

--- a/apps/api/src/fromschema.route.test.js
+++ b/apps/api/src/fromschema.route.test.js
@@ -176,3 +176,16 @@ test('/v1/generate/fromschema supports pairwise query flag', async () => {
     ['Safari', 'Dark'],
   ]);
 });
+
+test('/v1/generate/fromschema accepts comments and blank lines in schema text', async () => {
+  const response = await fetch(url('/v1/generate/fromschema?rowCount=2&outputFormat=json'), {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain' },
+    body: '# skip me\n\nPriority\nenum(high,medium,low)\n\n# and me\nStatus\nenum(active,inactive,pending)',
+  });
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.headers).toEqual(['Priority', 'Status']);
+  expect(body.rows).toHaveLength(2);
+});

--- a/apps/cli/src/tests/run-cli.test.js
+++ b/apps/cli/src/tests/run-cli.test.js
@@ -177,3 +177,27 @@ test('generates deterministic pairwise output in buffered mode', async () => {
     { Browser: 'Safari', Theme: 'Dark' },
   ]);
 });
+
+test('supports comments and blank lines in input schema', async () => {
+  const platform = makePlatform({
+    textSpec: '# comment\n\nPriority\nenum(high,medium,low)\n\nStatus\nenum(active,inactive,pending)',
+  });
+  const code = await runCliCommand({
+    platform,
+    options: {
+      inputFile: 'spec.txt',
+      outputFile: null,
+      format: 'json',
+      rowCount: 2,
+      testMode: false,
+      showProgress: false,
+      shouldStream: false,
+      unsafeFakerExpressions: false,
+      pairwise: false,
+    },
+  });
+  expect(code).toBe(0);
+  const parsed = JSON.parse(platform.out.join('').trim());
+  expect(parsed).toHaveLength(2);
+  expect(Object.keys(parsed[0])).toEqual(['Priority', 'Status']);
+});

--- a/apps/mcp/src/mcp.test.js
+++ b/apps/mcp/src/mcp.test.js
@@ -49,6 +49,26 @@ test('MCP server handles generate_data_from_spec tool call', () => {
   expect(response?.result?.structuredContent?.ok).toBe(true);
 });
 
+test('MCP server accepts comments and blank lines in textSpec', () => {
+  const response = requestServer({
+    jsonrpc: '2.0',
+    id: 201,
+    method: 'tools/call',
+    params: {
+      name: 'generate_data_from_spec',
+      arguments: {
+        textSpec: '# comment\n\nPriority\nenum(high,medium,low)\nStatus\nenum(active,inactive,pending)',
+        rowCount: 1,
+        outputFormat: 'json',
+      },
+    },
+  });
+  const payload = JSON.parse(response?.result?.content?.[0]?.text || '{}');
+  expect(payload.ok).toBe(true);
+  expect(payload.headers).toEqual(['Priority', 'Status']);
+  expect(payload.rows).toHaveLength(1);
+});
+
 test('MCP server supports pairwise generation', () => {
   const response = requestServer({
     jsonrpc: '2.0',

--- a/apps/web/src/tests/browser/planned-functional/test-data/text-schema.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/test-data/text-schema.spec.js
@@ -9,18 +9,18 @@ test.describe('7. Test Data Generation', () => {
     await appPage.testDataPanel.expectExpanded();
     const beforeSchema = await appPage.testDataPanel.getSchemaRowCount();
 
-    await appPage.testDataPanel.addSchemaRow();
-    await expect.poll(async () => appPage.testDataPanel.getSchemaRowCount()).toBe(beforeSchema + 1);
-
-    const schemaRowIndex = beforeSchema;
-    await appPage.testDataPanel.setSchemaCell(schemaRowIndex, 'columnName', 'First Name');
-    await appPage.testDataPanel.setSchemaTypeValue(schemaRowIndex, 'faker');
-    await appPage.testDataPanel.setSchemaCell(schemaRowIndex, 'value', 'faker.person.firstName');
+    await appPage.testDataPanel.setSchemaText(
+      '# this comment should be ignored\n\nFirst Name\nperson.firstName\n\n# second comment\nStatus\nenum(active,inactive,pending)'
+    );
+    await expect.poll(async () => appPage.testDataPanel.getSchemaRowCount()).toBe(beforeSchema + 2);
     await appPage.testDataPanel.setGenerateCount(5);
 
     await appPage.testDataPanel.clickGenerate();
     await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(5);
     await expect.poll(async () => appPage.gridEditor.header.getColumnNames()).toContain('First Name');
+    await expect.poll(async () => appPage.gridEditor.header.getColumnNames()).toContain('Status');
+    // comments are not rendered as schema rows
+    expect(await appPage.testDataPanel.getSchemaRowCount()).toBe(beforeSchema + 2);
 
     const values = await appPage.gridEditor.renderer.getColumnTextsByName('First Name');
     expect(values.filter(Boolean).length).toBe(5);

--- a/docs-src/docs/040-test-data/040-literal-test-data.md
+++ b/docs-src/docs/040-test-data/040-literal-test-data.md
@@ -31,6 +31,7 @@ Schema text format uses:
 For a literal column:
 
 ```text
+# deployment context
 Environment
 UAT
 ```
@@ -42,10 +43,15 @@ If you generate 5 rows, every row in `Environment` will be `UAT`.
 You can define several static columns at once:
 
 ```text
+# locale defaults
 Country
 UK
+
+# currency defaults
 Currency
 GBP
+
+# workflow state
 Status
 ACTIVE
 ```
@@ -57,12 +63,19 @@ This is useful for creating baseline datasets quickly.
 Literal values are often combined with Faker and Regex columns.
 
 ```text
+# constant label
 Environment
 UAT
+
+# generated identity
 Customer Name
 person.fullName
+
+# generated order id
 Order Ref
 [A-Z]{3}-[0-9]{6}
+
+# constant flag
 Is Premium
 true
 ```

--- a/docs-src/docs/040-test-data/050-pairwise-testing.md
+++ b/docs-src/docs/040-test-data/050-pairwise-testing.md
@@ -36,10 +36,15 @@ Pairwise testing is most effective when:
 1. **Open the Test Data section** by clicking the "Test Data" header
 2. **Define your enum parameters** in the Test Data Text Schema:
    ```
+   # categorical parameters
    color
    red,blue,green,yellow
+
+   # sizing options
    size  
    small,medium,large
+
+   # material choices
    material
    wood,metal
    ```
@@ -66,8 +71,11 @@ AnyWayData supports multiple formats for specifying enum values in pairwise test
 The basic format uses comma-separated values:
 
 ```
+# pairwise field 1
 Priority
 high,medium,low
+
+# pairwise field 2
 Status  
 active,inactive,pending
 ```
@@ -78,24 +86,33 @@ For more complex scenarios, you can use function-based formats:
 
 #### Basic enum() Function
 ```
+# function style enum
 Priority
 enum(high,medium,low)
+
+# another function style enum
 Status
 enum(active,inactive,pending)
 ```
 
 #### Datatype enum() Function  
 ```
+# datatype enum form
 Priority
 datatype.enum(high,medium,low)
+
+# second datatype enum
 Status
 datatype.enum(active,inactive,pending)
 ```
 
 #### Full AWD enum() Function
 ```
+# fully-qualified enum form
 Priority
 awd.datatype.enum(high,medium,low)
+
+# fully-qualified enum form
 Status
 awd.datatype.enum(active,inactive,pending)
 ```
@@ -105,10 +122,15 @@ awd.datatype.enum(active,inactive,pending)
 When your enum values contain commas or special characters, use quoted values:
 
 ```
+# values containing commas
 Product Category
 enum("Hardware, Electronics","Software, Applications","Books, Media")
+
+# geo values containing commas
 Location
 enum("New York, NY","Los Angeles, CA","Chicago, IL")
+
+# status text with commas
 Status Message
 enum("Ready, waiting for input","Processing, please wait","Error, check configuration")
 ```
@@ -118,8 +140,11 @@ enum("Ready, waiting for input","Processing, please wait","Error, check configur
 You can mix quoted and unquoted values in the same enum:
 
 ```
+# mixed quoting example
 Environment
 enum("Production, Live",staging,development,"Test, QA")
+
+# mixed quoting example
 User Type
 enum("Admin, Full Access",editor,viewer,"Guest, Limited")
 ```
@@ -136,10 +161,15 @@ Consider testing an API with both categorical parameters (that need pairwise cov
 - Then random values User ID, etc.
 
 ```
+# pairwise enums
 HTTP Method
 enum(GET,POST,PUT,DELETE)
+
+# pairwise enums
 Content Type  
 enum("application/json","application/xml","text/plain")
+
+# randomized fields
 User ID
 faker.number.int
 Email Address
@@ -200,8 +230,11 @@ AnyWayData uses a greedy set cover approximation algorithm that:
 Example Input Schema:
 
 ```csv
+# simple pairwise schema
 color
 red,blue,green,yellow
+
+# simple pairwise schema
 size  
 small,medium,large
 ```

--- a/docs-src/docs/040-test-data/050-pairwise-testing.md
+++ b/docs-src/docs/040-test-data/050-pairwise-testing.md
@@ -31,6 +31,14 @@ Pairwise testing is most effective when:
 
 ## How to Generate Pairwise Data
 
+## Schema Formatting
+
+Schema text supports:
+
+- **Comments**: lines starting with `#` (after optional leading whitespace) are treated as comments.
+- **Blank lines**: allowed and ignored, useful for readability between column groups.
+- **Column definitions**: each column name must be followed by its generation rule on the next logical content line.
+
 ### In the Main App (app.html)
 
 1. **Open the Test Data section** by clicking the "Test Data" header

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -151,7 +151,7 @@ Generate JSON output with a JSON payload:
 curl -X POST http://localhost:3000/v1/generate \
   -H "Content-Type: application/json" \
   -d '{
-    "textSpec": "Name\nBob\n\nCity\nlondon",
+    "textSpec": "# literal values\n\nName\nBob\n\n# lower-case city\nCity\nlondon",
     "rowCount": 3,
     "outputFormat": "json"
   }'
@@ -163,7 +163,7 @@ Generate CSV output with CSV-specific options:
 curl -X POST http://localhost:3000/v1/generate \
   -H "Content-Type: application/json" \
   -d '{
-    "textSpec": "Name\nBob",
+    "textSpec": "# basic csv schema\n\nName\nBob",
     "rowCount": 2,
     "outputFormat": "csv",
     "options": {
@@ -180,7 +180,7 @@ Generate using raw schema text (`fromschema`):
 ```bash
 curl -X POST "http://localhost:3000/v1/generate/fromschema?outputFormat=markdown&rowCount=2" \
   -H "Content-Type: text/plain" \
-  --data-binary $'Name\nBob\n\nId\n1'
+  --data-binary $'# markdown sample\n\nName\nBob\n\n# numeric id\nId\n1'
 ```
 
 Get current options for a format:

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -137,6 +137,14 @@ Use endpoints at `http://localhost:8082`.
 
 Both endpoints generate data from the same schema language and output formats. The key difference is request shape and content type, not generation capability.
 
+## Schema Formatting
+
+Schema text supports:
+
+- **Comments**: lines starting with `#` (after optional leading whitespace) are treated as comments.
+- **Blank lines**: allowed and ignored, useful for readability between column groups.
+- **Column definitions**: each column name must be followed by its generation rule on the next logical content line.
+
 ## API Examples
 
 Health check:

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -48,6 +48,14 @@ Parameter guide for the examples:
 - `--unsafe-faker-expressions`: opt-in to expression-style faker arguments (unsafe for untrusted input).
 - `--help`: show CLI usage and options.
 
+## Schema Formatting
+
+Schema text supports:
+
+- **Comments**: lines starting with `#` (after optional leading whitespace) are treated as comments.
+- **Blank lines**: allowed and ignored, useful for readability between column groups.
+- **Column definitions**: each column name must be followed by its generation rule on the next logical content line.
+
 ## Behavior Notes
 
 - `--testMode` always forces generation to a single row (`rowCount = 1`) and prints diagnostic/example output.

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -61,10 +61,15 @@ Parameter guide for the examples:
 Example `input.txt` schema file:
 
 ```text
+# identity fields
 Name
 person.fullName
+
+# contact details
 Email
 internet.email
+
+# historical date
 JoinedOn
 date.past
 ```

--- a/packages/core-ui/js/gui_components/data-generator-page.js
+++ b/packages/core-ui/js/gui_components/data-generator-page.js
@@ -76,10 +76,54 @@ function schemaRowsToSpec(schemaRows) {
     if (name.length === 0 && ruleSpec.length === 0) {
       return;
     }
+    const comments = String(row?.comments ?? '');
+    if (comments.length > 0) {
+      lines.push(...comments.split('\n'));
+    }
     lines.push(name);
     lines.push(ruleSpec);
   });
   return lines.join('\n');
+}
+
+function schemaRowsToSpecWithTokens(schemaRows, schemaTokens) {
+  const hasRowComments = (schemaRows || []).some((row) => String(row?.comments ?? '').length > 0);
+  if (hasRowComments) {
+    return schemaRowsToSpec(schemaRows);
+  }
+  const rows = (schemaRows || []).map((row) => ({
+    name: String(row?.name ?? '').trim(),
+    rule: buildRuleSpecFromSchemaRow(row),
+  }));
+  const tokens = Array.isArray(schemaTokens) ? schemaTokens : [];
+  if (tokens.length === 0) {
+    return schemaRowsToSpec(schemaRows);
+  }
+
+  const outputLines = [];
+  let rowIndex = 0;
+  tokens.forEach((token) => {
+    if (token?.kind === 'comment' || token?.kind === 'blank') {
+      outputLines.push(token.text ?? '');
+      return;
+    }
+    if (token?.kind === 'rule' && rowIndex < rows.length) {
+      outputLines.push(rows[rowIndex].name);
+      outputLines.push(rows[rowIndex].rule);
+      rowIndex += 1;
+    }
+  });
+
+  while (rowIndex < rows.length) {
+    if (outputLines.length > 0) {
+      outputLines.push('');
+    }
+    outputLines.push(rows[rowIndex].name);
+    outputLines.push(rows[rowIndex].rule);
+    rowIndex += 1;
+  }
+
+  return outputLines.join('\n');
 }
 
 function validateSchemaRows(schemaRows) {
@@ -92,6 +136,7 @@ function validateSchemaRows(schemaRows) {
       command: normaliseFakerCommand(row?.command),
       params: String(row?.params ?? '').trim(),
       value: String(row?.value ?? '').trim(),
+      comments: String(row?.comments ?? ''),
       order: index,
     };
   });
@@ -148,6 +193,7 @@ class DataGeneratorPage {
 
     this.rowIdCounter = 1;
     this.schemaRows = [];
+    this.schemaTextTokens = [];
     this.fakerCommands = getKnownFakerCommandsAlphabetical().filter((command) => command !== 'RegEx');
     this.fakerCommandsLongestFirst = getKnownFakerCommandsLongestFirst().filter((command) => command !== 'RegEx');
     this.isTextMode = false;
@@ -202,6 +248,7 @@ class DataGeneratorPage {
       command: '',
       params: '',
       value: '',
+      comments: '',
     };
   }
 
@@ -606,6 +653,7 @@ class DataGeneratorPage {
         return;
       }
       this.schemaRows = parsed.rows.length > 0 ? parsed.rows : [this.createBlankSchemaRow()];
+      this.schemaTextTokens = parsed.tokens || [];
       this.renderSchemaRows();
       this.isTextMode = false;
       this.updateSchemaEditModeView();
@@ -613,7 +661,7 @@ class DataGeneratorPage {
     }
 
     const textArea = this.documentObj.getElementById('generatorSchemaText');
-    textArea.value = schemaRowsToSpec(this.schemaRows);
+    textArea.value = schemaRowsToSpecWithTokens(this.schemaRows, this.schemaTextTokens);
     this.isTextMode = true;
     this.updateSchemaEditModeView();
   }
@@ -634,23 +682,25 @@ class DataGeneratorPage {
   parseSchemaTextToRows(schemaText) {
     const text = String(schemaText ?? '');
     if (text.trim().length === 0) {
-      return { rows: [], errors: [] };
+      return { rows: [], errors: [], tokens: [] };
     }
 
     const generator = new this.TestDataGeneratorClass(this.faker, this.RandExp);
     generator.importSpec(text);
     generator.compile();
     if (!generator.isValid()) {
-      return { rows: [], errors: generator.errors() };
+      return { rows: [], errors: generator.errors(), tokens: [] };
     }
 
     const rows = generator.testDataRules().map((rule) => this.ruleToSchemaRow(rule));
-    return { rows, errors: [] };
+    const tokens =
+      typeof generator.rulesParser?.getSchemaTokens === 'function' ? generator.rulesParser.getSchemaTokens() : [];
+    return { rows, errors: [], tokens };
   }
 
   syncSchemaRowsFromTextMode({ showErrors = false } = {}) {
     if (!this.isTextMode) {
-      return { rows: this.schemaRows, errors: [] };
+      return { rows: this.schemaRows, errors: [], tokens: this.schemaTextTokens };
     }
 
     const textArea = this.documentObj.getElementById('generatorSchemaText');
@@ -665,12 +715,14 @@ class DataGeneratorPage {
     // Keep empty text schemas as zero rows while in text mode so validation can
     // report "Add at least one schema row." instead of introducing a synthetic blank row.
     this.schemaRows = parsed.rows;
-    return { rows: this.schemaRows, errors: [] };
+    this.schemaTextTokens = parsed.tokens || [];
+    return { rows: this.schemaRows, errors: [], tokens: this.schemaTextTokens };
   }
 
   ruleToSchemaRow(rule) {
     const row = this.createBlankSchemaRow();
     row.name = String(rule?.name ?? '');
+    row.comments = String(rule?.comments ?? '');
     row.sourceType = normaliseSourceType(rule?.type);
 
     if (row.sourceType === SOURCE_TYPE_FAKER) {
@@ -1332,4 +1384,11 @@ class DataGeneratorPage {
   }
 }
 
-export { DataGeneratorPage, buildRuleSpecFromSchemaRow, schemaRowsToSpec, validateSchemaRows, normaliseFakerCommand };
+export {
+  DataGeneratorPage,
+  buildRuleSpecFromSchemaRow,
+  schemaRowsToSpec,
+  schemaRowsToSpecWithTokens,
+  validateSchemaRows,
+  normaliseFakerCommand,
+};

--- a/packages/core-ui/js/gui_components/testdatadefn.js
+++ b/packages/core-ui/js/gui_components/testdatadefn.js
@@ -480,6 +480,7 @@ function populateTestDataGridFromRules() {
   for (let rule of generator.testDataRules()) {
     let data = {};
     data.columnName = rule.name;
+    data.comments = String(rule.comments ?? '');
     if (rule.type == 'faker') {
       // remove faker.
       let fakerFreeRule = rule.ruleSpec;
@@ -592,7 +593,7 @@ function setupTestDataEditGrid(gridDiv) {
     if (!defnGridBridge) {
       return;
     }
-    defnGridBridge.addRows([{ columnName: '', type: 'RegEx', value: '' }]);
+    defnGridBridge.addRows([{ columnName: '', type: 'RegEx', value: '', comments: '' }]);
     convertGridToText();
   });
 
@@ -754,22 +755,26 @@ function convertGridToText() {
     return;
   }
 
-  let outputText = '';
-  let prefix = '';
+  const outputLines = [];
   defnGridBridge.getRows().forEach((rowData) => {
     const resolvedRowData =
       activeDefnCellEdit?.rowData === rowData
         ? { ...rowData, [activeDefnCellEdit.field]: activeDefnCellEdit.value }
         : rowData;
-    outputText = outputText + prefix;
-    outputText = outputText + (resolvedRowData.columnName || '') + '\n';
+    const leadingComments = String(resolvedRowData.comments ?? '');
+    if (leadingComments.length > 0) {
+      outputLines.push(...leadingComments.split('\n'));
+    }
 
+    outputLines.push(resolvedRowData.columnName || '');
+
+    let ruleLine = '';
     switch (resolvedRowData.type) {
       case 'RegEx':
-        outputText = outputText + (resolvedRowData.value || '');
+        ruleLine = resolvedRowData.value || '';
         break;
       case 'enum':
-        outputText = outputText + (resolvedRowData.value || '');
+        ruleLine = resolvedRowData.value || '';
         break;
       // TODO Literal
       default: {
@@ -778,7 +783,7 @@ function convertGridToText() {
           dataType = dataType.replace('faker.', '');
         }
         if (FAKER_COMMANDS.includes(dataType)) {
-          outputText = outputText + dataType + (resolvedRowData.value || '');
+          ruleLine = dataType + (resolvedRowData.value || '');
         } else {
           // throw error? ignore? don't know what the command is so it won't parse
           // ignoring
@@ -786,10 +791,10 @@ function convertGridToText() {
         }
       }
     }
-    prefix = '\n';
+    outputLines.push(ruleLine);
   });
 
-  document.getElementById('testdatadefntext').value = outputText;
+  document.getElementById('testdatadefntext').value = outputLines.join('\n');
   updatePairwiseButtonVisibility();
 }
 

--- a/packages/core-ui/src/tests/generator/data-generator-page.test.js
+++ b/packages/core-ui/src/tests/generator/data-generator-page.test.js
@@ -3,6 +3,7 @@ import {
   DataGeneratorPage,
   buildRuleSpecFromSchemaRow,
   schemaRowsToSpec,
+  schemaRowsToSpecWithTokens,
   validateSchemaRows,
 } from '../../../js/gui_components/data-generator-page.js';
 
@@ -68,6 +69,10 @@ class FakeTestDataGenerator {
   constructor() {
     this.rules = [];
     this._errors = [];
+    this._tokens = [];
+    this.rulesParser = {
+      getSchemaTokens: () => this._tokens.map((token) => ({ ...token })),
+    };
     this.compiler = {
       validate: () => {},
     };
@@ -76,15 +81,35 @@ class FakeTestDataGenerator {
   importSpec(text) {
     const lines = text.split('\n');
     this.rules = [];
-    for (let i = 0; i < lines.length; i += 2) {
-      if (lines[i] === undefined || lines[i + 1] === undefined) {
+    this._tokens = [];
+    let pendingName = null;
+    let pendingComments = [];
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      const trimmed = String(line ?? '').trim();
+      if (trimmed.length === 0) {
+        this._tokens.push({ kind: 'blank', text: line });
+        pendingComments.push(line);
+        continue;
+      }
+      if (/^\s*#/.test(line)) {
+        this._tokens.push({ kind: 'comment', text: line });
+        pendingComments.push(line);
+        continue;
+      }
+      if (pendingName === null) {
+        pendingName = trimmed;
         continue;
       }
       this.rules.push({
-        name: lines[i],
-        ruleSpec: lines[i + 1],
+        name: pendingName,
+        ruleSpec: trimmed,
+        comments: pendingComments.join('\n'),
         type: '',
       });
+      this._tokens.push({ kind: 'rule', name: pendingName, rule: trimmed });
+      pendingName = null;
+      pendingComments = [];
     }
   }
 
@@ -159,6 +184,17 @@ describe('DataGeneratorPage', () => {
   test('schemaRowsToSpec omits fully blank rows', () => {
     const spec = schemaRowsToSpec([{ name: '', sourceType: 'regex', value: '' }]);
     expect(spec).toBe('');
+  });
+
+  test('schemaRowsToSpecWithTokens preserves comments and blank lines', () => {
+    const spec = schemaRowsToSpecWithTokens(
+      [
+        { name: 'Priority', sourceType: 'enum', value: 'enum(high,medium,low)' },
+        { name: 'Status', sourceType: 'enum', value: 'enum(active,inactive,pending)' },
+      ],
+      [{ kind: 'comment', text: '# top' }, { kind: 'rule' }, { kind: 'blank', text: '' }, { kind: 'rule' }]
+    );
+    expect(spec).toBe('# top\nPriority\nenum(high,medium,low)\n\nStatus\nenum(active,inactive,pending)');
   });
 
   test('uses curated alphabetical faker command list in schema editor', () => {
@@ -792,6 +828,71 @@ describe('DataGeneratorPage', () => {
     expect(page.schemaRows[0].name).toBe('City');
     expect(page.schemaRows[0].value).toBe('[A-Z]{4}');
     expect(page.schemaRows[0].sourceType).toBe('regex');
+  });
+
+  test('text mode preserves comments while schema rows exclude them', () => {
+    const page = new DataGeneratorPage({
+      parentElement: document.getElementById('app'),
+      documentObj: document,
+      alertFn,
+      faker: { word: { noun: () => 'x' } },
+      RandExp: function RandExp() {},
+      TabulatorCtor: FakeTabulator,
+      GridExtensionClass: FakeGridExtension,
+      ExporterClass: FakeExporter,
+      DownloadClass: FakeDownload,
+      TestDataGeneratorClass: FakeTestDataGenerator,
+    });
+    page.init();
+
+    const toggle = document.getElementById('schemaModeToggleButton');
+    toggle.click();
+
+    const textArea = document.getElementById('generatorSchemaText');
+    textArea.value = '# note\nPriority\nenum(high,medium,low)\n\nStatus\nenum(active,inactive,pending)';
+    toggle.click();
+
+    expect(page.schemaRows.length).toBe(2);
+    expect(page.schemaRows[0].name).toBe('Priority');
+    expect(page.schemaRows[1].name).toBe('Status');
+
+    toggle.click();
+    expect(document.getElementById('generatorSchemaText').value).toContain('# note');
+  });
+
+  test('adding schema rows does not discard existing parsed comments', () => {
+    const page = new DataGeneratorPage({
+      parentElement: document.getElementById('app'),
+      documentObj: document,
+      alertFn,
+      faker: { word: { noun: () => 'x' } },
+      RandExp: function RandExp() {},
+      TabulatorCtor: FakeTabulator,
+      GridExtensionClass: FakeGridExtension,
+      ExporterClass: FakeExporter,
+      DownloadClass: FakeDownload,
+      TestDataGeneratorClass: FakeTestDataGenerator,
+    });
+    page.init();
+
+    let toggle = document.getElementById('schemaModeToggleButton');
+    toggle.click();
+    const textArea = document.getElementById('generatorSchemaText');
+    textArea.value = '# note one\nFirst\none\n\n# note two\nSecond\ntwo';
+    toggle.click();
+
+    page.addRowAfter(page.schemaRows.length - 1);
+    const newRow = page.schemaRows[page.schemaRows.length - 1];
+    newRow.name = 'Third';
+    newRow.sourceType = 'literal';
+    newRow.value = 'three';
+
+    toggle = document.getElementById('schemaModeToggleButton');
+    toggle.click();
+    const rebuilt = document.getElementById('generatorSchemaText').value;
+    expect(rebuilt).toContain('# note one');
+    expect(rebuilt).toContain('# note two');
+    expect(rebuilt).toContain('Third\nthree');
   });
 
   test('edit as text shows empty textarea for untouched blank schema', () => {

--- a/packages/core-ui/src/tests/generator/data-generator-page.test.js
+++ b/packages/core-ui/src/tests/generator/data-generator-page.test.js
@@ -81,6 +81,7 @@ class FakeTestDataGenerator {
   importSpec(text) {
     const lines = text.split('\n');
     this.rules = [];
+    this._errors = [];
     this._tokens = [];
     let pendingName = null;
     let pendingComments = [];
@@ -88,11 +89,15 @@ class FakeTestDataGenerator {
       const line = lines[i];
       const trimmed = String(line ?? '').trim();
       if (trimmed.length === 0) {
+        if (pendingName !== null) {
+          this._errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
+          return;
+        }
         this._tokens.push({ kind: 'blank', text: line });
         pendingComments.push(line);
         continue;
       }
-      if (/^\s*#/.test(line)) {
+      if (pendingName === null && /^\s*#/.test(line)) {
         this._tokens.push({ kind: 'comment', text: line });
         pendingComments.push(line);
         continue;
@@ -110,6 +115,13 @@ class FakeTestDataGenerator {
       this._tokens.push({ kind: 'rule', name: pendingName, rule: trimmed });
       pendingName = null;
       pendingComments = [];
+    }
+    if (pendingName !== null) {
+      this._errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
+      return;
+    }
+    if (this.rules.length === 0) {
+      this._errors.push('ERROR: No Rules Defined');
     }
   }
 
@@ -858,6 +870,34 @@ describe('DataGeneratorPage', () => {
 
     toggle.click();
     expect(document.getElementById('generatorSchemaText').value).toContain('# note');
+  });
+
+  test('text mode accepts hash-prefixed rule text after a column name', () => {
+    const page = new DataGeneratorPage({
+      parentElement: document.getElementById('app'),
+      documentObj: document,
+      alertFn,
+      faker: { word: { noun: () => 'x' } },
+      RandExp: function RandExp() {},
+      TabulatorCtor: FakeTabulator,
+      GridExtensionClass: FakeGridExtension,
+      ExporterClass: FakeExporter,
+      DownloadClass: FakeDownload,
+      TestDataGeneratorClass: FakeTestDataGenerator,
+    });
+    page.init();
+
+    const toggle = document.getElementById('schemaModeToggleButton');
+    toggle.click();
+
+    const textArea = document.getElementById('generatorSchemaText');
+    textArea.value = 'Color\n#[A-F0-9]{6}';
+    toggle.click();
+
+    expect(alertFn).not.toHaveBeenCalled();
+    expect(page.schemaRows.length).toBe(1);
+    expect(page.schemaRows[0].name).toBe('Color');
+    expect(page.schemaRows[0].value).toBe('#[A-F0-9]{6}');
   });
 
   test('adding schema rows does not discard existing parsed comments', () => {

--- a/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
+++ b/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
@@ -400,6 +400,39 @@ describe('test data definition editor engine compatibility', () => {
     delete global.Tabulator;
   });
 
+  test('schema text comments survive text-to-grid parse and add-column grid sync', async () => {
+    const TabulatorMock = installTabulatorMock();
+
+    enableTestDataGenerationInterface(
+      'host',
+      {
+        setGridFromGenericDataTable: jest.fn(),
+      },
+      {
+        renderTextFromGrid: jest.fn(),
+      },
+      {
+        getRowCount: jest.fn(() => 0),
+        getSelectedRowIndexes: jest.fn(() => []),
+      }
+    );
+
+    const schemaTextArea = document.getElementById('testdatadefntext');
+    schemaTextArea.value =
+      '# first comment\n\nPriority\nenum(high,medium,low)\n\n# second comment\nStatus\nenum(active,inactive)';
+    schemaTextArea.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await flushUi();
+
+    expect(TabulatorMock.latestInstance.rows).toHaveLength(2);
+    document.querySelector('#defngrid button').click();
+    await flushUi();
+
+    const rebuilt = document.getElementById('testdatadefntext').value;
+    expect(rebuilt).toContain('# first comment');
+    expect(rebuilt).toContain('# second comment');
+  });
+
   test('load sample schema button populates text schema with literal, enum, regex, and faker examples', () => {
     installTabulatorMock();
 

--- a/packages/core/js/data_generation/rulesParser.js
+++ b/packages/core/js/data_generation/rulesParser.js
@@ -7,45 +7,134 @@ export class RulesParser {
     this.options = options;
     this.testDataRules = new TestDataRules();
     this.errors = [];
+    this.schemaTokens = [];
   }
 
   parseText(textContent) {
-    const defnLines = textContent.split('\n');
+    this.testDataRules = new TestDataRules();
+    this.errors = [];
+    this.schemaTokens = [];
 
-    if (defnLines.length % 2 !== 0) {
-      this.errors.push(
-        'ERROR: Specification should be ColumnName followed by RuleDefinition with an even number of lines'
-      );
-    }
-
-    if (defnLines.length === 0 || (defnLines.length === 1 && defnLines[0].length === 0)) {
+    const defnLines = String(textContent ?? '').split('\n');
+    if (defnLines.length === 0 || (defnLines.length === 1 && defnLines[0].trim().length === 0)) {
       this.errors.push('ERROR: No Rules Defined');
       return;
     }
 
-    // add rules to dataDefn
-    for (var index = 0; index < defnLines.length; index += 2) {
-      const name = defnLines[index].trim();
+    let pendingName = null;
+    let pendingNameLine = null;
+    let pendingLeadingTextLines = [];
 
-      if (name.length === 0) {
-        this.errors.push(`ERROR: Missing Name on line ${index + 1}`);
-        return;
+    for (let index = 0; index < defnLines.length; index++) {
+      const line = defnLines[index];
+      const trimmed = line.trim();
+
+      if (trimmed.length === 0) {
+        if (pendingName !== null) {
+          this.errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
+          return;
+        }
+        this.schemaTokens.push({ kind: 'blank', text: line, line: index + 1 });
+        pendingLeadingTextLines.push(line);
+        continue;
       }
 
-      if (index + 1 == defnLines.length) {
-        this.errors.push(`ERROR: Missing Rule Definition for ${name}`);
-        return;
+      if (/^\s*#/.test(line)) {
+        if (pendingName !== null) {
+          this.errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
+          return;
+        }
+        this.schemaTokens.push({ kind: 'comment', text: line, line: index + 1 });
+        pendingLeadingTextLines.push(line);
+        continue;
       }
 
-      const rule = defnLines[index + 1];
-
-      if (rule.trim().length === 0) {
-        this.errors.push(`ERROR: Missing Rule on line ${index + 2}`);
-        return;
+      if (pendingName === null) {
+        pendingName = trimmed;
+        pendingNameLine = index + 1;
+        continue;
       }
 
-      this.testDataRules.addRule(name.trim(), rule.trim());
+      const rule = trimmed;
+      this.testDataRules.addRule(pendingName, rule, {
+        comments: pendingLeadingTextLines.join('\n'),
+      });
+      this.schemaTokens.push({
+        kind: 'rule',
+        name: pendingName,
+        rule,
+        headerLine: pendingNameLine,
+        ruleLine: index + 1,
+      });
+      pendingName = null;
+      pendingNameLine = null;
+      pendingLeadingTextLines = [];
     }
+
+    if (pendingName !== null) {
+      this.errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
+      return;
+    }
+
+    if (this.testDataRules.rules.length === 0) {
+      this.errors.push('ERROR: No Rules Defined');
+    }
+  }
+
+  getSchemaTokens() {
+    return this.schemaTokens.map((token) => ({ ...token }));
+  }
+
+  renderSpecFromRulesWithTokens(rules) {
+    const rows = Array.isArray(rules)
+      ? rules.map((rule) => ({
+          name: String(rule?.name ?? ''),
+          rule: String(rule?.ruleSpec ?? ''),
+        }))
+      : [];
+    const outputLines = [];
+    let rowIndex = 0;
+
+    this.schemaTokens.forEach((token) => {
+      if (token.kind === 'comment' || token.kind === 'blank') {
+        outputLines.push(token.text ?? '');
+        return;
+      }
+      if (token.kind === 'rule') {
+        if (rowIndex < rows.length) {
+          outputLines.push(rows[rowIndex].name);
+          outputLines.push(rows[rowIndex].rule);
+          rowIndex += 1;
+        }
+      }
+    });
+
+    while (rowIndex < rows.length) {
+      if (outputLines.length > 0) {
+        outputLines.push('');
+      }
+      outputLines.push(rows[rowIndex].name);
+      outputLines.push(rows[rowIndex].rule);
+      rowIndex += 1;
+    }
+
+    return outputLines.join('\n');
+  }
+
+  renderSpecFromRulesWithComments(rules) {
+    const safeRules = Array.isArray(rules) ? rules : [];
+    const outputLines = [];
+    safeRules.forEach((rule) => {
+      const comments = String(rule?.comments ?? '');
+      if (comments.length > 0) {
+        const commentLines = comments.split('\n');
+        outputLines.push(...commentLines);
+      }
+
+      outputLines.push(String(rule?.name ?? ''));
+      outputLines.push(String(rule?.ruleSpec ?? ''));
+    });
+    return outputLines.join('\n');
   }
 
   isValid() {

--- a/packages/core/js/data_generation/rulesParser.js
+++ b/packages/core/js/data_generation/rulesParser.js
@@ -39,17 +39,12 @@ export class RulesParser {
         continue;
       }
 
-      if (/^\s*#/.test(line)) {
-        if (pendingName !== null) {
-          this.errors.push(`ERROR: Missing Rule Definition for ${pendingName}`);
-          return;
-        }
-        this.schemaTokens.push({ kind: 'comment', text: line, line: index + 1 });
-        pendingLeadingTextLines.push(line);
-        continue;
-      }
-
       if (pendingName === null) {
+        if (/^\s*#/.test(line)) {
+          this.schemaTokens.push({ kind: 'comment', text: line, line: index + 1 });
+          pendingLeadingTextLines.push(line);
+          continue;
+        }
         pendingName = trimmed;
         pendingNameLine = index + 1;
         continue;

--- a/packages/core/js/data_generation/testDataRule.js
+++ b/packages/core/js/data_generation/testDataRule.js
@@ -11,9 +11,11 @@ export const RuleType = {
 };
 
 class TestDataRule {
-  constructor(aName, aRule = '') {
+  constructor(aName, aRule = '', options = {}) {
     this.name = aName;
     this.ruleSpec = aRule;
+    // Preserve comment/blank-line text found immediately before this rule in schema text.
+    this.comments = String(options?.comments ?? '');
     // we don't know what the command is until we compile it
     this.fakerCommand = '';
     this.type = RuleType.UNKNOWN; // by default unknown type,

--- a/packages/core/js/data_generation/testDataRules.js
+++ b/packages/core/js/data_generation/testDataRules.js
@@ -23,8 +23,8 @@ class TestDataRules {
     return retRules[0];
   }
 
-  addRule(aName, aRule) {
-    this.rules.push(new TestDataRule(aName.trim(), aRule));
+  addRule(aName, aRule, options = {}) {
+    this.rules.push(new TestDataRule(aName.trim(), aRule, options));
   }
 }
 

--- a/packages/core/src/tests/core-api/generateFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/generateFromTextSpec.test.js
@@ -24,6 +24,17 @@ test('generateFromTextSpec accepts comments and blank lines in spec', () => {
   expect(result.rows.length).toBe(2);
 });
 
+test('generateFromTextSpec accepts # prefixed rule content lines', () => {
+  const result = generateFromTextSpec({
+    textSpec: 'Color\n#[A-F0-9]{6}',
+    rowCount: 2,
+    outputFormat: 'json',
+  });
+  expect(result.ok).toBe(true);
+  expect(result.headers).toEqual(['Color']);
+  expect(result.rows).toHaveLength(2);
+});
+
 test('generateFromTextSpec renders test framework output', () => {
   const result = generateFromTextSpec({ textSpec: 'Name\nBob', rowCount: 1, outputFormat: 'pytest' });
   expect(result.ok).toBe(true);

--- a/packages/core/src/tests/core-api/generateFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/generateFromTextSpec.test.js
@@ -13,6 +13,17 @@ test('generateFromTextSpec generates rows for valid spec', () => {
   expect(result.rows.length).toBe(2);
 });
 
+test('generateFromTextSpec accepts comments and blank lines in spec', () => {
+  const result = generateFromTextSpec({
+    textSpec: '# comment\n\nPriority\nenum(high,medium,low)\n\nStatus\nenum(active,inactive,pending)',
+    rowCount: 2,
+    outputFormat: 'json',
+  });
+  expect(result.ok).toBe(true);
+  expect(result.headers).toEqual(['Priority', 'Status']);
+  expect(result.rows.length).toBe(2);
+});
+
 test('generateFromTextSpec renders test framework output', () => {
   const result = generateFromTextSpec({ textSpec: 'Name\nBob', rowCount: 1, outputFormat: 'pytest' });
   expect(result.ok).toBe(true);

--- a/packages/core/src/tests/data_generation/generateDataFromMultiLineSpec.test.js
+++ b/packages/core/src/tests/data_generation/generateDataFromMultiLineSpec.test.js
@@ -55,7 +55,7 @@ describe('TestDataGenerator meets Acceptance Criteria', () => {
       generator.compile();
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()).toContain('ERROR: Missing Rule on line 2');
+      expect(generator.errors()).toContain('ERROR: Missing Rule Definition for Column1');
       expect(generator.testDataRules().length).toBe(0);
     });
 
@@ -123,7 +123,7 @@ describe('TestDataGenerator meets Acceptance Criteria', () => {
       const data = generator.generate(1);
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()).toContain('ERROR: Missing Rule on line 2');
+      expect(generator.errors()).toContain('ERROR: Missing Rule Definition for Column1');
       expect(data).toStrictEqual([[], []]);
     });
 
@@ -157,11 +157,8 @@ describe('TestDataGenerator meets Acceptance Criteria', () => {
       generator.compile();
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()[0]).toBe(
-        'ERROR: Specification should be ColumnName followed by RuleDefinition with an even number of lines'
-      );
-      expect(generator.errors()[1]).toBe('ERROR: No Rules Defined');
-      expect(generator.errors().length).toBe(2);
+      expect(generator.errors()[0]).toBe('ERROR: No Rules Defined');
+      expect(generator.errors().length).toBe(1);
     });
 
     test('can identify malformed file', () => {
@@ -171,11 +168,8 @@ describe('TestDataGenerator meets Acceptance Criteria', () => {
       generator.compile();
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()[0]).toBe(
-        'ERROR: Specification should be ColumnName followed by RuleDefinition with an even number of lines'
-      );
-      expect(generator.errors()[1]).toBe('ERROR: Missing Rule Definition for Field1');
-      expect(generator.errors().length).toBe(2);
+      expect(generator.errors()[0]).toBe('ERROR: Missing Rule Definition for Field1');
+      expect(generator.errors().length).toBe(1);
     });
 
     test('can identify Rule with a missing definition', () => {
@@ -185,21 +179,18 @@ describe('TestDataGenerator meets Acceptance Criteria', () => {
       generator.compile();
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()[0]).toBe(
-        'ERROR: Specification should be ColumnName followed by RuleDefinition with an even number of lines'
-      );
-      expect(generator.errors()[1]).toBe('ERROR: Missing Rule Definition for Field2');
-      expect(generator.errors().length).toBe(2);
+      expect(generator.errors()[0]).toBe('ERROR: Missing Rule Definition for Field2');
+      expect(generator.errors().length).toBe(1);
     });
 
-    test('can identify Rule with a missing name', () => {
+    test('can identify rule with missing definition after comment/blank lines', () => {
       const generator = new TestDataGenerator(faker, RandExp);
-      generator.importSpec('Field1\nvalue1\n\n');
+      generator.importSpec('Field1\nvalue1\n\n# trailing comment\nField2\n');
 
       generator.compile();
 
       expect(generator.isValid()).toBe(false);
-      expect(generator.errors()[0]).toBe('ERROR: Missing Name on line 3');
+      expect(generator.errors()[0]).toBe('ERROR: Missing Rule Definition for Field2');
       expect(generator.errors().length).toBe(1);
     });
   });

--- a/packages/core/src/tests/data_generation/unit/rulesParser.test.js
+++ b/packages/core/src/tests/data_generation/unit/rulesParser.test.js
@@ -65,13 +65,24 @@ enum(active,inactive,pending)
     expect(parser.testDataRules.rules).toHaveLength(0);
   });
 
-  test('rejects comment lines between header and rule definition', () => {
+  test('rejects blank lines between header and rule definition', () => {
     const parser = new RulesParser(faker, RandExp);
-    parser.parseText('Priority\n# not allowed here\nenum(high,medium,low)');
+    parser.parseText('Priority\n\nenum(high,medium,low)');
 
     expect(parser.isValid()).toBe(false);
     expect(parser.errors).toContain('ERROR: Missing Rule Definition for Priority');
     expect(parser.testDataRules.rules).toHaveLength(0);
+  });
+
+  test('accepts rule lines that begin with # when header is pending', () => {
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText('Color\n#[A-F0-9]{6}');
+
+    expect(parser.isValid()).toBe(true);
+    expect(parser.errors).toHaveLength(0);
+    expect(parser.testDataRules.rules).toHaveLength(1);
+    expect(parser.testDataRules.rules[0].name).toBe('Color');
+    expect(parser.testDataRules.rules[0].ruleSpec).toBe('#[A-F0-9]{6}');
   });
 
   test('preserves comments and blank lines when rebuilding from parsed tokens', () => {

--- a/packages/core/src/tests/data_generation/unit/rulesParser.test.js
+++ b/packages/core/src/tests/data_generation/unit/rulesParser.test.js
@@ -27,7 +27,81 @@ person.fullName`;
     parser.parseText(inputText);
 
     expect(parser.isValid()).toBe(false);
-    expect(parser.errors).toContain('ERROR: Missing Rule on line 2');
+    expect(parser.errors).toContain('ERROR: Missing Rule Definition for Name');
     expect(parser.testDataRules.rules).toHaveLength(0);
+  });
+
+  test('allows comment and blank lines around schema definitions', () => {
+    const inputText = `# top comment
+
+Priority
+enum(high,medium,low)
+
+  # in between
+Status
+enum(active,inactive,pending)
+`;
+
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText(inputText);
+
+    expect(parser.isValid()).toBe(true);
+    expect(parser.testDataRules.rules).toHaveLength(2);
+    expect(parser.testDataRules.rules[0].name).toBe('Priority');
+    expect(parser.testDataRules.rules[1].name).toBe('Status');
+    expect(parser.testDataRules.rules[0].comments).toContain('# top comment');
+    expect(parser.testDataRules.rules[1].comments).toContain('# in between');
+    const tokens = parser.getSchemaTokens();
+    expect(tokens.some((token) => token.kind === 'comment')).toBe(true);
+    expect(tokens.some((token) => token.kind === 'blank')).toBe(true);
+  });
+
+  test('rejects comment-only or blank-only schema text', () => {
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText('# note\n\n  # another');
+
+    expect(parser.isValid()).toBe(false);
+    expect(parser.errors).toContain('ERROR: No Rules Defined');
+    expect(parser.testDataRules.rules).toHaveLength(0);
+  });
+
+  test('rejects comment lines between header and rule definition', () => {
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText('Priority\n# not allowed here\nenum(high,medium,low)');
+
+    expect(parser.isValid()).toBe(false);
+    expect(parser.errors).toContain('ERROR: Missing Rule Definition for Priority');
+    expect(parser.testDataRules.rules).toHaveLength(0);
+  });
+
+  test('preserves comments and blank lines when rebuilding from parsed tokens', () => {
+    const inputText = `# a comment that should be skipped
+Priority
+enum(high,medium,low)
+
+Status
+enum(active,inactive,pending)`;
+
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText(inputText);
+
+    const output = parser.renderSpecFromRulesWithTokens(parser.testDataRules.rules);
+    expect(output).toBe(inputText);
+  });
+
+  test('preserves comments and blank lines when rebuilding from rule comments', () => {
+    const inputText = `# one
+
+Priority
+enum(high,medium,low)
+
+# two
+Status
+enum(active,inactive,pending)`;
+    const parser = new RulesParser(faker, RandExp);
+    parser.parseText(inputText);
+
+    const output = parser.renderSpecFromRulesWithComments(parser.testDataRules.rules);
+    expect(output).toBe(inputText);
   });
 });


### PR DESCRIPTION
closes #47 
closes #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema text now accepts and preserves comment lines (starting with #) and blank lines; comments are ignored for generation and retained when switching between text and grid modes.

* **Documentation**
  * Updated README, REST API, CLI and test-data docs with annotated, clearer schema examples (including escaped-newline API examples).

* **Tests**
  * Added/updated end-to-end and unit tests validating comment/blank-line parsing, preservation, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->