### PR TITLE
42 amend calls in api and mcp and cli

### DIFF
--- a/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/app-page-abstractions-smoke.spec.js
@@ -47,7 +47,7 @@ test('add row button creates row in grid', async ({ page }) => {
   await appPage.gridEditor.addRow();
   await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(initialRowCount + 1);
   const rowCountAfterAdd = await appPage.gridEditor.renderer.countRows();
-  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
+  await appPage.gridEditor.header.expectHasAnyColumns();
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
   expect(primaryColumnName).toBeTruthy();
 

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/grid-editor-controls.spec.js
@@ -60,7 +60,7 @@ test('quick filter and clear filters update visible rows', async ({ page }) => {
   await appPage.gridEditor.addRow();
   await appPage.gridEditor.addRow();
   await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(2);
-  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
+  await appPage.gridEditor.header.expectHasAnyColumns();
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
   expect(primaryColumnName).toBeTruthy();
   await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 0, 'Filter Match');

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/grid-header-controls.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/grid-header-controls.spec.js
@@ -39,12 +39,12 @@ test('grid header sorting and per-column filter change visible results', async (
 
   await appPage.gridEditor.header.sortDesc(targetColumnName);
   await expect
-    .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(targetColumnName)).slice(0, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
     .toEqual(['Cherry', 'Banana', 'Apple']);
 
   await appPage.gridEditor.header.sortAsc(targetColumnName);
   await expect
-    .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(targetColumnName)).slice(0, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
 
   await appPage.gridEditor.header.setColumnFilter(targetColumnName, 'Cherry');
@@ -56,7 +56,7 @@ test('grid header sorting and per-column filter change visible results', async (
   await appPage.gridEditor.header.setColumnFilter(targetColumnName, '');
   await expect.poll(async () => appPage.gridEditor.header.getColumnFilterValue(targetColumnName)).toBe('');
   await expect
-    .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(targetColumnName)).slice(0, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/grid-header-controls.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/grid-header-controls.spec.js
@@ -39,12 +39,12 @@ test('grid header sorting and per-column filter change visible results', async (
 
   await appPage.gridEditor.header.sortDesc(targetColumnName);
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(targetColumnName, 3))
     .toEqual(['Cherry', 'Banana', 'Apple']);
 
   await appPage.gridEditor.header.sortAsc(targetColumnName);
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(targetColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
 
   await appPage.gridEditor.header.setColumnFilter(targetColumnName, 'Cherry');
@@ -56,7 +56,7 @@ test('grid header sorting and per-column filter change visible results', async (
   await appPage.gridEditor.header.setColumnFilter(targetColumnName, '');
   await expect.poll(async () => appPage.gridEditor.header.getColumnFilterValue(targetColumnName)).toBe('');
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(targetColumnName, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(targetColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/tabbed-formats-options.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/tabbed-formats-options.spec.js
@@ -69,9 +69,9 @@ test('all format options become dirty and apply cleanly', async ({ page }) => {
     expect(await appPage.formatOptionsPanel.isApplyEnabled()).toBe(false);
 
     await appPage.formatOptionsPanel.setFirstEditableOption();
-    await expect.poll(async () => appPage.formatOptionsPanel.isApplyEnabled()).toBe(true);
+    await appPage.formatOptionsPanel.expectApplyEnabled(true);
     await appPage.formatOptionsPanel.apply();
-    await expect.poll(async () => appPage.formatOptionsPanel.isApplyEnabled()).toBe(false);
+    await appPage.formatOptionsPanel.expectApplyEnabled(false);
   }
 
   expect(pageErrors).toEqual([]);
@@ -86,11 +86,11 @@ test('preview edit mode and set-grid-from-text state transitions are correct', a
   expect(await appPage.tabbedText.getPreviewEditLabel()).toContain('Preview');
 
   await appPage.tabbedText.togglePreviewEdit(false);
-  await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toBe('Edit');
+  await appPage.tabbedText.expectPreviewEditLabel('Edit');
   expect(await appPage.importExportControls.isSetGridFromTextEnabled()).toBe(true);
 
   await appPage.tabbedText.togglePreviewEdit();
-  await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toContain('Preview');
+  await appPage.tabbedText.expectPreviewEditLabelContains('Preview');
   expect(await appPage.importExportControls.isSetGridFromTextEnabled()).toBe(false);
 
   expect(pageErrors).toEqual([]);

--- a/apps/web/src/tests/browser/abstractions/app.page.js
+++ b/apps/web/src/tests/browser/abstractions/app.page.js
@@ -1,3 +1,4 @@
+const { expect } = require('@playwright/test');
 const { TopNavigationComponent } = require('./components/top-navigation.component');
 const { GridEditorComponent } = require('./components/grid-editor.component');
 const { ImportExportControlsComponent } = require('./components/import-export-controls.component');
@@ -25,7 +26,7 @@ class AppPage {
   }
 
   async waitUntilReady() {
-    await this.initialLoading.waitFor({ state: 'hidden' });
+    await expect(this.initialLoading).toBeHidden();
     await this.topNavigation.expectReady();
     await this.gridEditor.expectReady();
     await this.importExportControls.expectReady();

--- a/apps/web/src/tests/browser/abstractions/components/format-options-panel.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/format-options-panel.component.js
@@ -24,6 +24,15 @@ class FormatOptionsPanelComponent {
     return button.isEnabled();
   }
 
+  async expectApplyEnabled(enabled = true) {
+    const button = this.container.locator('.apply-options').first();
+    if (enabled) {
+      await expect(button).toBeEnabled();
+      return;
+    }
+    await expect(button).toBeDisabled();
+  }
+
   async apply() {
     await this.container.locator('.apply-options').first().click();
   }

--- a/apps/web/src/tests/browser/abstractions/components/format-options-panel.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/format-options-panel.component.js
@@ -1,3 +1,5 @@
+const { expect } = require('@playwright/test');
+
 class FormatOptionsPanelComponent {
   constructor(page) {
     this.page = page;
@@ -5,12 +7,12 @@ class FormatOptionsPanelComponent {
   }
 
   async expectVisible() {
-    await this.container.waitFor({ state: 'visible' });
+    await expect(this.container).toBeVisible();
   }
 
   async expectReady() {
     await this.expectVisible();
-    await this.container.locator('.apply-options').first().waitFor({ state: 'visible' });
+    await expect(this.container.locator('.apply-options').first()).toBeVisible();
   }
 
   async hasApplyButton() {

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -20,21 +20,21 @@ class GridEditorComponent {
   }
 
   async expectVisible() {
-    await this.container.waitFor({ state: 'visible' });
-    await this.grid.waitFor({ state: 'visible' });
-    await this.addRowButton.waitFor({ state: 'visible' });
-    await this.addRowsAboveButton.waitFor({ state: 'visible' });
-    await this.addRowsBelowButton.waitFor({ state: 'visible' });
-    await this.deleteSelectedRowsButton.waitFor({ state: 'visible' });
-    await this.quickFilterInput.waitFor({ state: 'visible' });
-    await this.clearFiltersButton.waitFor({ state: 'visible' });
-    await this.clearSortButton.waitFor({ state: 'visible' });
-    await this.resetTableButton.waitFor({ state: 'visible' });
+    await expect(this.container).toBeVisible();
+    await expect(this.grid).toBeVisible();
+    await expect(this.addRowButton).toBeVisible();
+    await expect(this.addRowsAboveButton).toBeVisible();
+    await expect(this.addRowsBelowButton).toBeVisible();
+    await expect(this.deleteSelectedRowsButton).toBeVisible();
+    await expect(this.quickFilterInput).toBeVisible();
+    await expect(this.clearFiltersButton).toBeVisible();
+    await expect(this.clearSortButton).toBeVisible();
+    await expect(this.resetTableButton).toBeVisible();
   }
 
   async expectReady() {
     await this.expectVisible();
-    await this.grid.locator('.tabulator-col-title').first().waitFor({ state: 'visible' });
+    await expect(this.grid.locator('.tabulator-col-title').first()).toBeVisible();
   }
 
   async addRow() {

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -7,7 +7,7 @@ class GridEditorComponent {
     this.container = page.locator('#main-grid-view');
     this.grid = page.locator('#myGrid');
     this.renderer = new GridRendererComponent(page, this.grid);
-    this.header = new GridHeaderComponent(page, this.grid);
+    this.header = new GridHeaderComponent(page, this.grid, this.renderer);
     this.addRowButton = page.getByRole('button', { name: 'Add Row', exact: true });
     this.addRowsAboveButton = page.getByRole('button', { name: 'Add Rows Above' });
     this.addRowsBelowButton = page.getByRole('button', { name: 'Add Rows Below' });
@@ -84,21 +84,63 @@ class GridEditorComponent {
     await this.renderer.selectRows(rowIndexes);
   }
 
-  async clearFilters() {
+  async clearFilters({ expectedActiveRowCount } = {}) {
+    const initialActiveRowCount = await this.renderer.getActiveRowCount();
+    const columnNames = await this.header.getColumnNames();
+    const diagnosticColumn = columnNames[0];
     for (let attempt = 0; attempt < 3; attempt += 1) {
       await this.clearFiltersButton.click();
-      for (let check = 0; check < 20; check += 1) {
+      for (let check = 0; check < 30; check += 1) {
         const quickFilterValue = await this.quickFilterInput.inputValue();
-        const hasActiveColumnFilter = await this.grid
+        const headerFilterValues = await this.grid
           .locator('.tabulator-header-filter input')
-          .evaluateAll((inputs) => inputs.some((input) => String(input.value || '').trim().length > 0));
-        if (quickFilterValue === '' && !hasActiveColumnFilter) {
-          return;
+          .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
+        const hasActiveColumnFilter = headerFilterValues.some((value) => value.length > 0);
+        const activeRowCount = await this.renderer.getActiveRowCount();
+
+        const filtersAreCleared = quickFilterValue === '' && !hasActiveColumnFilter;
+        const rowCountRecovered = Number.isFinite(expectedActiveRowCount)
+          ? activeRowCount === expectedActiveRowCount
+          : activeRowCount > initialActiveRowCount;
+
+        if (filtersAreCleared && rowCountRecovered) {
+          await this.renderer.waitForGridSettle({ columnName: diagnosticColumn, stableForMs: 2000, timeoutMs: 7000 });
+
+          const quickFilterAfterSettle = await this.quickFilterInput.inputValue();
+          const headerFilterValuesAfterSettle = await this.grid
+            .locator('.tabulator-header-filter input')
+            .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
+          const activeRowCountAfterSettle = await this.renderer.getActiveRowCount();
+          const filtersStillCleared =
+            quickFilterAfterSettle === '' && !headerFilterValuesAfterSettle.some((value) => value.length > 0);
+          const rowCountStillRecovered = Number.isFinite(expectedActiveRowCount)
+            ? activeRowCountAfterSettle === expectedActiveRowCount
+            : activeRowCountAfterSettle > initialActiveRowCount;
+          if (filtersStillCleared && rowCountStillRecovered) {
+            return;
+          }
         }
         await this.page.waitForTimeout(50);
       }
     }
-    throw new Error('Failed to clear all filters.');
+
+    const quickFilterValue = await this.quickFilterInput.inputValue();
+    const headerFilterValues = await this.grid
+      .locator('.tabulator-header-filter input')
+      .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
+    const activeRowCount = await this.renderer.getActiveRowCount();
+    const snapshot = await this.renderer.getActiveTableSnapshot(diagnosticColumn, 3);
+    throw new Error(
+      [
+        'Failed to clear all filters and restore active rows.',
+        `quickFilter="${quickFilterValue}"`,
+        `headerFilters=${JSON.stringify(headerFilterValues)}`,
+        `activeRowCount=${activeRowCount}`,
+        `expectedActiveRowCount=${Number.isFinite(expectedActiveRowCount) ? expectedActiveRowCount : 'n/a'}`,
+        `diagnosticColumn=${diagnosticColumn || 'n/a'}`,
+        `topValues=${JSON.stringify(snapshot.topValues || [])}`,
+      ].join(' ')
+    );
   }
 
   async clearSort() {

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -1,3 +1,4 @@
+const { expect } = require('@playwright/test');
 const { GridRendererComponent } = require('./grid-renderer.component');
 const { GridHeaderComponent } = require('./grid-header.component');
 
@@ -85,65 +86,89 @@ class GridEditorComponent {
   }
 
   async clearFilters({ expectedActiveRowCount } = {}) {
+    const context = await this._buildClearFiltersContext(expectedActiveRowCount);
+
+    try {
+      await expect(async () => {
+        await this._attemptClearFilters(context);
+      }).toPass({ timeout: 15000, intervals: [100, 200, 400, 800] });
+      return;
+    } catch (error) {
+      // fall through to detailed diagnostics
+    }
+
+    await this._throwClearFiltersDiagnostics(context);
+  }
+
+  async _attemptClearFilters(context) {
+    await this.clearFiltersButton.click();
+    await expect(this.quickFilterInput).toHaveValue('');
+    await this._expectHeaderFiltersCleared();
+    await this._expectActiveRowCountRecovered(context);
+    await this.renderer.waitForGridSettle({ columnName: context.diagnosticColumn, stableForMs: 2000, timeoutMs: 7000 });
+    await this._expectHeaderFiltersCleared();
+    await this._expectActiveRowCountRecovered(context);
+  }
+
+  async _buildClearFiltersContext(expectedActiveRowCount) {
     const initialActiveRowCount = await this.renderer.getActiveRowCount();
     const columnNames = await this.header.getColumnNames();
     const diagnosticColumn = columnNames[0];
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      await this.clearFiltersButton.click();
-      for (let check = 0; check < 30; check += 1) {
-        const quickFilterValue = await this.quickFilterInput.inputValue();
-        const headerFilterValues = await this.grid
-          .locator('.tabulator-header-filter input')
-          .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
-        const hasActiveColumnFilter = headerFilterValues.some((value) => value.length > 0);
-        const activeRowCount = await this.renderer.getActiveRowCount();
+    const hadActiveFiltersBeforeClear = await this._hasActiveFilters();
+    const minRecoveredRowCount =
+      hadActiveFiltersBeforeClear && !Number.isFinite(expectedActiveRowCount)
+        ? initialActiveRowCount + 1
+        : initialActiveRowCount;
+    return {
+      expectedActiveRowCount,
+      initialActiveRowCount,
+      diagnosticColumn,
+      minRecoveredRowCount,
+    };
+  }
 
-        const filtersAreCleared = quickFilterValue === '' && !hasActiveColumnFilter;
-        const rowCountRecovered = Number.isFinite(expectedActiveRowCount)
-          ? activeRowCount === expectedActiveRowCount
-          : activeRowCount >= initialActiveRowCount;
-
-        if (filtersAreCleared && rowCountRecovered) {
-          try {
-            await this.renderer.waitForGridSettle({ columnName: diagnosticColumn, stableForMs: 2000, timeoutMs: 7000 });
-          } catch (error) {
-            // Let retry loop continue so we can recover from transient settle timing.
-            await this.page.waitForTimeout(50);
-            continue;
-          }
-
-          const quickFilterAfterSettle = await this.quickFilterInput.inputValue();
-          const headerFilterValuesAfterSettle = await this.grid
-            .locator('.tabulator-header-filter input')
-            .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
-          const activeRowCountAfterSettle = await this.renderer.getActiveRowCount();
-          const filtersStillCleared =
-            quickFilterAfterSettle === '' && !headerFilterValuesAfterSettle.some((value) => value.length > 0);
-          const rowCountStillRecovered = Number.isFinite(expectedActiveRowCount)
-            ? activeRowCountAfterSettle === expectedActiveRowCount
-            : activeRowCountAfterSettle >= initialActiveRowCount;
-          if (filtersStillCleared && rowCountStillRecovered) {
-            return;
-          }
-        }
-        await this.page.waitForTimeout(50);
-      }
-    }
-
+  async _hasActiveFilters() {
     const quickFilterValue = await this.quickFilterInput.inputValue();
-    const headerFilterValues = await this.grid
+    if (String(quickFilterValue || '').trim().length > 0) {
+      return true;
+    }
+    const headerFilterValues = await this._getHeaderFilterValues();
+    return headerFilterValues.some((value) => value.length > 0);
+  }
+
+  async _getHeaderFilterValues() {
+    return this.grid
       .locator('.tabulator-header-filter input')
       .evaluateAll((inputs) => inputs.map((input) => String(input.value || '').trim()));
+  }
+
+  async _expectHeaderFiltersCleared() {
+    const headerFilterValues = await this._getHeaderFilterValues();
+    expect(headerFilterValues.some((value) => value.length > 0)).toBe(false);
+  }
+
+  async _expectActiveRowCountRecovered(context) {
     const activeRowCount = await this.renderer.getActiveRowCount();
-    const snapshot = await this.renderer.getActiveTableSnapshot(diagnosticColumn, 3);
+    if (Number.isFinite(context.expectedActiveRowCount)) {
+      expect(activeRowCount).toBe(context.expectedActiveRowCount);
+    } else {
+      expect(activeRowCount).toBeGreaterThanOrEqual(context.minRecoveredRowCount);
+    }
+  }
+
+  async _throwClearFiltersDiagnostics(context) {
+    const quickFilterValue = await this.quickFilterInput.inputValue();
+    const headerFilterValues = await this._getHeaderFilterValues();
+    const activeRowCount = await this.renderer.getActiveRowCount();
+    const snapshot = await this.renderer.getActiveTableSnapshot(context.diagnosticColumn, 3);
     throw new Error(
       [
         'Failed to clear all filters and restore active rows.',
         `quickFilter="${quickFilterValue}"`,
         `headerFilters=${JSON.stringify(headerFilterValues)}`,
         `activeRowCount=${activeRowCount}`,
-        `expectedActiveRowCount=${Number.isFinite(expectedActiveRowCount) ? expectedActiveRowCount : 'n/a'}`,
-        `diagnosticColumn=${diagnosticColumn || 'n/a'}`,
+        `expectedActiveRowCount=${Number.isFinite(context.expectedActiveRowCount) ? context.expectedActiveRowCount : 'n/a'}`,
+        `diagnosticColumn=${context.diagnosticColumn || 'n/a'}`,
         `topValues=${JSON.stringify(snapshot.topValues || [])}`,
       ].join(' ')
     );

--- a/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-editor.component.js
@@ -101,10 +101,16 @@ class GridEditorComponent {
         const filtersAreCleared = quickFilterValue === '' && !hasActiveColumnFilter;
         const rowCountRecovered = Number.isFinite(expectedActiveRowCount)
           ? activeRowCount === expectedActiveRowCount
-          : activeRowCount > initialActiveRowCount;
+          : activeRowCount >= initialActiveRowCount;
 
         if (filtersAreCleared && rowCountRecovered) {
-          await this.renderer.waitForGridSettle({ columnName: diagnosticColumn, stableForMs: 2000, timeoutMs: 7000 });
+          try {
+            await this.renderer.waitForGridSettle({ columnName: diagnosticColumn, stableForMs: 2000, timeoutMs: 7000 });
+          } catch (error) {
+            // Let retry loop continue so we can recover from transient settle timing.
+            await this.page.waitForTimeout(50);
+            continue;
+          }
 
           const quickFilterAfterSettle = await this.quickFilterInput.inputValue();
           const headerFilterValuesAfterSettle = await this.grid
@@ -115,7 +121,7 @@ class GridEditorComponent {
             quickFilterAfterSettle === '' && !headerFilterValuesAfterSettle.some((value) => value.length > 0);
           const rowCountStillRecovered = Number.isFinite(expectedActiveRowCount)
             ? activeRowCountAfterSettle === expectedActiveRowCount
-            : activeRowCountAfterSettle > initialActiveRowCount;
+            : activeRowCountAfterSettle >= initialActiveRowCount;
           if (filtersStillCleared && rowCountStillRecovered) {
             return;
           }

--- a/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
@@ -23,6 +23,10 @@ class GridHeaderComponent {
     return this.gridRoot.locator('.tabulator-col .tabulator-col-title').count();
   }
 
+  async expectHasAnyColumns() {
+    await expect(this.gridRoot.locator('.tabulator-col .tabulator-col-title').first()).toBeVisible();
+  }
+
   async clickAction(columnName, action) {
     const headerTitle = this._headerTitleByName(columnName);
     const actionTitleMap = {

--- a/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
@@ -1,3 +1,4 @@
+const { expect } = require('@playwright/test');
 const { GridRendererComponent } = require('./grid-renderer.component');
 
 class GridHeaderComponent {
@@ -110,17 +111,11 @@ class GridHeaderComponent {
   }
 
   async _ensureSortState(columnName, expectedState, action) {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
+    await expect(async () => {
       await this.clickAction(columnName, action);
-      for (let check = 0; check < 10; check += 1) {
-        const state = await this.getColumnSortState(columnName);
-        if (String(state).includes(expectedState)) {
-          return;
-        }
-        await this.page.waitForTimeout(50);
-      }
-    }
-    throw new Error(`Failed to set sort state '${expectedState}' for column '${columnName}'.`);
+      const state = await this.getColumnSortState(columnName);
+      expect(String(state)).toContain(expectedState);
+    }).toPass({ timeout: 3000, intervals: [100, 200, 400] });
   }
 
   _headerTitleByName(columnName) {

--- a/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-header.component.js
@@ -1,8 +1,11 @@
+const { GridRendererComponent } = require('./grid-renderer.component');
+
 class GridHeaderComponent {
-  constructor(page, gridRootLocator) {
+  constructor(page, gridRootLocator, renderer = undefined) {
     this.page = page;
     this.gridRoot = gridRootLocator;
     this.headers = this.gridRoot.locator('.tabulator-col');
+    this.renderer = renderer || new GridRendererComponent(page, gridRootLocator);
   }
 
   async getColumnNames() {
@@ -74,10 +77,12 @@ class GridHeaderComponent {
 
   async sortAsc(columnName) {
     await this._ensureSortState(columnName, 'asc', 'sort-asc');
+    await this.renderer.waitForGridSettle({ columnName });
   }
 
   async sortDesc(columnName) {
     await this._ensureSortState(columnName, 'desc', 'sort-desc');
+    await this.renderer.waitForGridSettle({ columnName });
   }
 
   async clearSort(columnName) {

--- a/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
@@ -86,6 +86,41 @@ class GridRendererComponent {
     return values;
   }
 
+  async getTopActiveColumnTextsByName(columnName, count) {
+    const desiredCount = Number(count) || 0;
+    if (desiredCount <= 0) {
+      return [];
+    }
+    const normalizedName = this._normalizeColumnTitle(columnName);
+    return this.page.evaluate(
+      ({ normalizedName: targetColumnName, desiredCount: limit }) => {
+        const tables = globalThis?.Tabulator?.findTable?.('#myGrid') || [];
+        const table = tables[0];
+        if (!table) {
+          return [];
+        }
+
+        const normalize = (value) =>
+          String(value || '')
+            .split('\n')[0]
+            .trim();
+
+        const columnDef = (table.getColumnDefinitions?.() || []).find((definition) => {
+          const byTitle = normalize(definition?.title) === targetColumnName;
+          const byField = normalize(definition?.field) === targetColumnName;
+          return byTitle || byField;
+        });
+        if (!columnDef?.field) {
+          return [];
+        }
+
+        const rows = table.getData?.('active') || [];
+        return rows.slice(0, limit).map((row) => String(row?.[columnDef.field] ?? '').trim());
+      },
+      { normalizedName, desiredCount }
+    );
+  }
+
   async clickCellByColumnName(columnName, rowIndex) {
     const columnIndex = await this._columnIndexByName(columnName);
     await this.clickCell(columnIndex, rowIndex);

--- a/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
@@ -70,6 +70,22 @@ class GridRendererComponent {
     return values;
   }
 
+  async getTopVisibleColumnTextsByName(columnName, count) {
+    const desiredCount = Number(count) || 0;
+    if (desiredCount <= 0) {
+      return [];
+    }
+    const visibleRows = await this.countVisibleRows();
+    if (visibleRows < desiredCount) {
+      return [];
+    }
+    const values = [];
+    for (let rowIndex = 0; rowIndex < desiredCount; rowIndex += 1) {
+      values.push(await this.getCellTextByColumnName(columnName, rowIndex));
+    }
+    return values;
+  }
+
   async clickCellByColumnName(columnName, rowIndex) {
     const columnIndex = await this._columnIndexByName(columnName);
     await this.clickCell(columnIndex, rowIndex);

--- a/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
@@ -30,11 +30,7 @@ class GridRendererComponent {
   }
 
   async waitForColumnName(columnName) {
-    await this.gridRoot
-      .locator('.tabulator-col-title')
-      .filter({ hasText: columnName })
-      .first()
-      .waitFor({ state: 'visible' });
+    await expect(this.gridRoot.locator('.tabulator-col-title').filter({ hasText: columnName }).first()).toBeVisible();
   }
 
   async clickCell(columnIndex, rowIndex) {

--- a/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
@@ -127,6 +127,73 @@ class GridRendererComponent {
     );
   }
 
+  async getActiveRowCount() {
+    return this.gridRoot.evaluate((root) => {
+      const tableFromRoot = root?.__tabulator;
+      const tableFromGlobal = globalThis?.Tabulator?.findTable?.('#myGrid')?.[0];
+      const table = tableFromRoot || tableFromGlobal;
+      if (!table) {
+        return 0;
+      }
+      const rows = table.getData?.('active') || [];
+      return Array.isArray(rows) ? rows.length : 0;
+    });
+  }
+
+  async getActiveColumnTextsByName(columnName, count) {
+    const desiredCount = Number(count) || 0;
+    if (desiredCount <= 0) {
+      return [];
+    }
+    return this.getTopActiveColumnTextsByName(columnName, desiredCount);
+  }
+
+  async getActiveTableSnapshot(columnName, sampleSize = 3) {
+    const desiredSampleSize = Math.max(0, Number(sampleSize) || 0);
+    const activeRowCount = await this.getActiveRowCount();
+    const topValues =
+      desiredSampleSize > 0 && columnName ? await this.getActiveColumnTextsByName(columnName, desiredSampleSize) : [];
+    return { activeRowCount, topValues };
+  }
+
+  async waitForGridSettle({
+    columnName,
+    sampleSize = 3,
+    stablePolls = 3,
+    stableForMs = 800,
+    timeoutMs = 5000,
+    pollIntervalMs = 75,
+  } = {}) {
+    const requiredStablePolls = Math.max(2, Number(stablePolls) || 2);
+    const desiredSampleSize = Math.max(0, Number(sampleSize) || 0);
+    const requiredStableForMs = Math.max(0, Number(stableForMs) || 0);
+    let stableCount = 0;
+    let lastSignature = '';
+    let stableSince = 0;
+
+    await expect
+      .poll(
+        async () => {
+          const now = Date.now();
+          const snapshot = await this.getActiveTableSnapshot(columnName, desiredSampleSize);
+          const signature = JSON.stringify(snapshot);
+          if (signature === lastSignature) {
+            stableCount += 1;
+          } else {
+            stableCount = 1;
+            lastSignature = signature;
+            stableSince = now;
+          }
+          const stableDuration = stableSince > 0 ? now - stableSince : 0;
+          return stableCount >= requiredStablePolls && stableDuration >= requiredStableForMs;
+        },
+        { timeout: timeoutMs, intervals: [pollIntervalMs] }
+      )
+      .toBe(true);
+
+    return this.getActiveTableSnapshot(columnName, desiredSampleSize);
+  }
+
   async clickCellByColumnName(columnName, rowIndex) {
     const columnIndex = await this._columnIndexByName(columnName);
     await this.clickCell(columnIndex, rowIndex);

--- a/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/grid-renderer.component.js
@@ -75,15 +75,20 @@ class GridRendererComponent {
     if (desiredCount <= 0) {
       return [];
     }
-    const visibleRows = await this.countVisibleRows();
-    if (visibleRows < desiredCount) {
-      return [];
-    }
-    const values = [];
-    for (let rowIndex = 0; rowIndex < desiredCount; rowIndex += 1) {
-      values.push(await this.getCellTextByColumnName(columnName, rowIndex));
-    }
-    return values;
+    const columnIndex = await this._columnIndexByName(columnName);
+    return this.gridRoot.evaluate(
+      (root, { targetColumnIndex, limit }) => {
+        const rowEls = Array.from(root.querySelectorAll('.tabulator-row')).filter((row) => row.offsetParent !== null);
+        if (rowEls.length < limit) {
+          return [];
+        }
+        return rowEls.slice(0, limit).map((row) => {
+          const cell = row.querySelectorAll('.tabulator-cell')[targetColumnIndex];
+          return String(cell?.textContent ?? '').trim();
+        });
+      },
+      { targetColumnIndex: columnIndex, limit: desiredCount }
+    );
   }
 
   async getTopActiveColumnTextsByName(columnName, count) {
@@ -92,10 +97,11 @@ class GridRendererComponent {
       return [];
     }
     const normalizedName = this._normalizeColumnTitle(columnName);
-    return this.page.evaluate(
-      ({ normalizedName: targetColumnName, desiredCount: limit }) => {
-        const tables = globalThis?.Tabulator?.findTable?.('#myGrid') || [];
-        const table = tables[0];
+    return this.gridRoot.evaluate(
+      (root, { normalizedName: targetColumnName, desiredCount: limit }) => {
+        const tableFromRoot = root?.__tabulator;
+        const tableFromGlobal = globalThis?.Tabulator?.findTable?.('#myGrid')?.[0];
+        const table = tableFromRoot || tableFromGlobal;
         if (!table) {
           return [];
         }

--- a/apps/web/src/tests/browser/abstractions/components/import-export-controls.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/import-export-controls.component.js
@@ -1,3 +1,5 @@
+const { expect } = require('@playwright/test');
+
 class ImportExportControlsComponent {
   constructor(page) {
     this.page = page;
@@ -13,9 +15,9 @@ class ImportExportControlsComponent {
   }
 
   async expectVisible() {
-    await this.container.waitFor({ state: 'visible' });
-    await this.setTextFromGridButton.waitFor({ state: 'visible' });
-    await this.downloadButton.waitFor({ state: 'visible' });
+    await expect(this.container).toBeVisible();
+    await expect(this.setTextFromGridButton).toBeVisible();
+    await expect(this.downloadButton).toBeVisible();
   }
 
   async expectReady() {

--- a/apps/web/src/tests/browser/abstractions/components/import-export-controls.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/import-export-controls.component.js
@@ -46,8 +46,20 @@ class ImportExportControlsComponent {
     return this.setGridFromTextButton.isEnabled();
   }
 
+  async expectSetGridFromTextEnabled(enabled = true) {
+    if (enabled) {
+      await expect(this.setGridFromTextButton).toBeEnabled();
+      return;
+    }
+    await expect(this.setGridFromTextButton).toBeDisabled();
+  }
+
   async getExtensionLabel() {
     return (await this.fileFormatLabel.innerText()).trim();
+  }
+
+  async expectExtensionLabel(value) {
+    await expect(this.fileFormatLabel).toHaveText(value);
   }
 
   async isImportVisible() {
@@ -64,6 +76,10 @@ class ImportExportControlsComponent {
 
   async getProgressStatusText() {
     return (await this.progressStatus.innerText()).trim();
+  }
+
+  async expectProgressStatusContains(value) {
+    await expect(this.progressStatus).toContainText(value);
   }
 }
 

--- a/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
@@ -83,6 +83,14 @@ class TabbedTextComponent {
     return (await this.previewOrEditButton.innerText()).trim();
   }
 
+  async expectPreviewEditLabel(value) {
+    await expect(this.previewOrEditButton).toHaveText(value);
+  }
+
+  async expectPreviewEditLabelContains(value) {
+    await expect(this.previewOrEditButton).toContainText(value);
+  }
+
   async setOutputText(value) {
     await this.outputTextArea.fill(value);
     await this.outputTextArea.dispatchEvent('input');
@@ -91,6 +99,10 @@ class TabbedTextComponent {
 
   async getOutputText() {
     return this.outputTextArea.inputValue();
+  }
+
+  async expectOutputContains(value) {
+    await expect(this.outputTextArea).toHaveValue(new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 }
 

--- a/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
@@ -1,3 +1,5 @@
+const { expect } = require('@playwright/test');
+
 class TabbedTextComponent {
   constructor(page) {
     this.page = page;
@@ -32,9 +34,9 @@ class TabbedTextComponent {
   }
 
   async expectVisible() {
-    await this.container.waitFor({ state: 'visible' });
-    await this.tabsList.waitFor({ state: 'visible' });
-    await this.copyButton.waitFor({ state: 'visible' });
+    await expect(this.container).toBeVisible();
+    await expect(this.tabsList).toBeVisible();
+    await expect(this.copyButton).toBeVisible();
   }
 
   async expectReady() {

--- a/apps/web/src/tests/browser/abstractions/components/test-data-panel.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/test-data-panel.component.js
@@ -22,8 +22,8 @@ class TestDataPanelComponent {
   }
 
   async expectVisible() {
-    await this.container.waitFor({ state: 'visible' });
-    await this.heading.waitFor({ state: 'visible' });
+    await expect(this.container).toBeVisible();
+    await expect(this.heading).toBeVisible();
   }
 
   async expectReady() {
@@ -43,11 +43,11 @@ class TestDataPanelComponent {
   }
 
   async expectExpanded() {
-    await this.generateButton.waitFor({ state: 'visible' });
-    await this.refreshTextPreviewButton.waitFor({ state: 'visible' });
-    await this.generateCountInput.waitFor({ state: 'visible' });
-    await this.schemaTextArea.waitFor({ state: 'visible' });
-    await this.schemaGrid.waitFor({ state: 'visible' });
+    await expect(this.generateButton).toBeVisible();
+    await expect(this.refreshTextPreviewButton).toBeVisible();
+    await expect(this.generateCountInput).toBeVisible();
+    await expect(this.schemaTextArea).toBeVisible();
+    await expect(this.schemaGrid).toBeVisible();
   }
 
   async isExpanded() {

--- a/apps/web/src/tests/browser/abstractions/components/top-navigation.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/top-navigation.component.js
@@ -63,6 +63,10 @@ class TopNavigationComponent {
   async isInstructionsExpanded() {
     return (await this.instructionsDetails.getAttribute('open')) !== null;
   }
+
+  async expectInstructionsExpanded(expanded = true) {
+    await expect(this.instructionsDetails).toHaveJSProperty('open', expanded === true);
+  }
 }
 
 module.exports = { TopNavigationComponent };

--- a/apps/web/src/tests/browser/abstractions/components/top-navigation.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/top-navigation.component.js
@@ -1,3 +1,5 @@
+const { expect } = require('@playwright/test');
+
 class TopNavigationComponent {
   constructor(page) {
     this.page = page;
@@ -10,10 +12,10 @@ class TopNavigationComponent {
   }
 
   async expectVisible() {
-    await this.brandLink.waitFor({ state: 'visible' });
-    await this.generatorLink.waitFor({ state: 'visible' });
-    await this.docsLink.waitFor({ state: 'visible' });
-    await this.blogLink.waitFor({ state: 'visible' });
+    await expect(this.brandLink).toBeVisible();
+    await expect(this.generatorLink).toBeVisible();
+    await expect(this.docsLink).toBeVisible();
+    await expect(this.blogLink).toBeVisible();
   }
 
   async expectReady() {

--- a/apps/web/src/tests/browser/app-coverage/export-formats/export-formats.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/export-formats/export-formats.spec.js
@@ -38,9 +38,9 @@ test('all export formats can render output text via page abstractions', async ({
   }
 
   await appPage.tabbedText.selectFormat('CSV');
-  await expect.poll(async () => appPage.importExportControls.getExtensionLabel()).toBe('.csv');
+  await appPage.importExportControls.expectExtensionLabel('.csv');
   await appPage.tabbedText.selectFormat('JSON');
-  await expect.poll(async () => appPage.importExportControls.getExtensionLabel()).toBe('.json');
+  await appPage.importExportControls.expectExtensionLabel('.json');
 
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/app-coverage/export-options/export-options.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/export-options/export-options.spec.js
@@ -11,11 +11,11 @@ test('format options become dirty, apply, and update output state', async ({ pag
   await appPage.importExportControls.setTextFromGrid();
   const before = await appPage.tabbedText.getOutputText();
 
-  await expect.poll(async () => appPage.formatOptionsPanel.isApplyEnabled()).toBe(false);
+  await appPage.formatOptionsPanel.expectApplyEnabled(false);
   await appPage.formatOptionsPanel.setFirstEditableOption();
-  await expect.poll(async () => appPage.formatOptionsPanel.isApplyEnabled()).toBe(true);
+  await appPage.formatOptionsPanel.expectApplyEnabled(true);
   await appPage.formatOptionsPanel.apply();
-  await expect.poll(async () => appPage.formatOptionsPanel.isApplyEnabled()).toBe(false);
+  await appPage.formatOptionsPanel.expectApplyEnabled(false);
 
   const after = await appPage.tabbedText.getOutputText();
   expect(after.length).toBeGreaterThan(0);
@@ -28,12 +28,12 @@ test('preview edit mode toggles and controls set-grid-from-text availability', a
   const appPage = new AppPage(page);
   await appPage.goto();
 
-  await expect.poll(async () => appPage.importExportControls.isSetGridFromTextEnabled()).toBe(false);
+  await appPage.importExportControls.expectSetGridFromTextEnabled(false);
   await appPage.tabbedText.togglePreviewEdit(false);
-  await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toBe('Edit');
-  await expect.poll(async () => appPage.importExportControls.isSetGridFromTextEnabled()).toBe(true);
+  await appPage.tabbedText.expectPreviewEditLabel('Edit');
+  await appPage.importExportControls.expectSetGridFromTextEnabled(true);
   await appPage.tabbedText.togglePreviewEdit();
-  await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toContain('Preview');
+  await appPage.tabbedText.expectPreviewEditLabelContains('Preview');
 
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
@@ -8,7 +8,7 @@ test('global filter, column filter, sort, and clear filters produce expected vis
   const appPage = new AppPage(page);
   await appPage.goto();
   await seedInstructionsRows(appPage, seededValues);
-  await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
+  await appPage.gridEditor.header.expectHasAnyColumns();
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
   const baselineActiveRowCount = seededValues.length;
   expect(primaryColumnName).toBeTruthy();

--- a/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
@@ -27,12 +27,12 @@ test('global filter, column filter, sort, and clear filters produce expected vis
 
   await appPage.gridEditor.header.sortAsc(primaryColumnName);
   await expect
-    .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(primaryColumnName)).slice(0, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(primaryColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
 
   await appPage.gridEditor.header.sortDesc(primaryColumnName);
   await expect
-    .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(primaryColumnName)).slice(0, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(primaryColumnName, 3))
     .toEqual(['Cherry', 'Banana', 'Apple']);
 
   expect(pageErrors).toEqual([]);

--- a/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
@@ -3,12 +3,14 @@ const { AppPage } = require('../../abstractions/app.page');
 const { trackPageErrors, seedInstructionsRows } = require('../helpers/test-helpers');
 
 test('global filter, column filter, sort, and clear filters produce expected visible state', async ({ page }) => {
+  const seededValues = ['Apple', 'Banana', 'Cherry'];
   const pageErrors = trackPageErrors(page);
   const appPage = new AppPage(page);
   await appPage.goto();
-  await seedInstructionsRows(appPage, ['Apple', 'Banana', 'Cherry']);
+  await seedInstructionsRows(appPage, seededValues);
   await expect.poll(async () => (await appPage.gridEditor.header.getColumnNames()).length).toBeGreaterThan(0);
   const [primaryColumnName] = await appPage.gridEditor.header.getColumnNames();
+  const baselineActiveRowCount = seededValues.length;
   expect(primaryColumnName).toBeTruthy();
 
   await appPage.gridEditor.setQuickFilter('App');
@@ -20,7 +22,8 @@ test('global filter, column filter, sort, and clear filters produce expected vis
   await appPage.gridEditor.header.setColumnFilter(primaryColumnName, 'App');
   await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(1);
 
-  await appPage.gridEditor.clearFilters();
+  await appPage.gridEditor.clearFilters({ expectedActiveRowCount: baselineActiveRowCount });
+  await expect.poll(async () => appPage.gridEditor.renderer.getActiveRowCount()).toBe(baselineActiveRowCount);
   await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(3);
   await expect.poll(async () => appPage.gridEditor.quickFilterInput.inputValue()).toBe('');
   await expect.poll(async () => appPage.gridEditor.header.getColumnFilterValue(primaryColumnName)).toBe('');

--- a/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/filtering-sorting/filtering-sorting.spec.js
@@ -27,12 +27,12 @@ test('global filter, column filter, sort, and clear filters produce expected vis
 
   await appPage.gridEditor.header.sortAsc(primaryColumnName);
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(primaryColumnName, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(primaryColumnName, 3))
     .toEqual(['Apple', 'Banana', 'Cherry']);
 
   await appPage.gridEditor.header.sortDesc(primaryColumnName);
   await expect
-    .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(primaryColumnName, 3))
+    .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(primaryColumnName, 3))
     .toEqual(['Cherry', 'Banana', 'Apple']);
 
   expect(pageErrors).toEqual([]);

--- a/apps/web/src/tests/browser/app-coverage/helpers/test-helpers.js
+++ b/apps/web/src/tests/browser/app-coverage/helpers/test-helpers.js
@@ -27,6 +27,8 @@ async function seedInstructionsRows(appPage, values) {
       .poll(async () => appPage.gridEditor.renderer.getCellTextByColumnName(primaryColumnName, i))
       .toBe(values[i]);
   }
+
+  await appPage.gridEditor.renderer.waitForGridSettle({ columnName: primaryColumnName, sampleSize: values.length });
 }
 
 module.exports = {

--- a/apps/web/src/tests/browser/app-coverage/import-export/import-export-basic.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/import-export/import-export-basic.spec.js
@@ -13,10 +13,10 @@ test('set text from grid and set grid from text round trip with csv', async ({ p
   await seedInstructionsRows(appPage, ['One', 'Two']);
   await appPage.tabbedText.selectFormat('CSV');
   await appPage.importExportControls.setTextFromGrid();
-  await expect.poll(async () => appPage.tabbedText.getOutputText()).toContain('One');
+  await appPage.tabbedText.expectOutputContains('One');
 
   await appPage.tabbedText.togglePreviewEdit(false);
-  await expect.poll(async () => appPage.importExportControls.isSetGridFromTextEnabled()).toBe(true);
+  await appPage.importExportControls.expectSetGridFromTextEnabled(true);
 
   await appPage.tabbedText.setOutputText('Name,Code\nAlice,A1\nBob,B2');
   await appPage.importExportControls.setGridFromText();
@@ -42,7 +42,7 @@ test('csv file upload imports into the grid and malformed csv does not crash pag
     await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(2);
 
     await appPage.tabbedText.togglePreviewEdit(false);
-    await expect.poll(async () => appPage.importExportControls.isSetGridFromTextEnabled()).toBe(true);
+    await appPage.importExportControls.expectSetGridFromTextEnabled(true);
     const rowsBeforeMalformedImport = await appPage.gridEditor.renderer.countRows();
     await appPage.tabbedText.setOutputText('"unterminated,quote\nfoo,bar');
     await appPage.importExportControls.setGridFromText();

--- a/apps/web/src/tests/browser/app-coverage/ui-navigation/ui-navigation.spec.js
+++ b/apps/web/src/tests/browser/app-coverage/ui-navigation/ui-navigation.spec.js
@@ -22,13 +22,13 @@ test('instructions panel expands and collapses with visible help content', async
   await appPage.goto();
 
   await appPage.topNavigation.expandInstructions();
-  await expect.poll(async () => appPage.topNavigation.isInstructionsExpanded()).toBe(true);
+  await appPage.topNavigation.expectInstructionsExpanded(true);
   await expect(
     page.locator('.instructions li', { hasText: 'Use tabs to switch between the type of text representation' })
   ).toBeVisible();
 
   await appPage.topNavigation.collapseInstructions();
-  await expect.poll(async () => appPage.topNavigation.isInstructionsExpanded()).toBe(false);
+  await appPage.topNavigation.expectInstructionsExpanded(false);
 
   expect(pageErrors).toEqual([]);
 });

--- a/apps/web/src/tests/browser/planned-functional/error-handling/invalid-import.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/error-handling/invalid-import.spec.js
@@ -25,7 +25,7 @@ test.describe('9. Error Handling and Edge Cases', () => {
       fs.writeFileSync(large, lines.join('\n'));
       await appPage.importExportControls.uploadFile(large);
       await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBeGreaterThan(0);
-      await expect.poll(async () => appPage.importExportControls.getProgressStatusText()).toBe('Import complete.');
+      await appPage.importExportControls.expectProgressStatusContains('Import complete.');
 
       const malformedUpload = path.join(tempDir, 'malformed.csv');
       fs.writeFileSync(malformedUpload, '"bad csv');

--- a/apps/web/src/tests/browser/planned-functional/export-options/preview-copy.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/export-options/preview-copy.spec.js
@@ -14,7 +14,7 @@ test.describe('6. Export Options and Controls', () => {
     await appPage.tabbedText.getOutputText();
 
     await appPage.tabbedText.togglePreviewEdit(true);
-    await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toContain('Edit');
+    await appPage.tabbedText.expectPreviewEditLabelContains('Edit');
     const previewText = await appPage.tabbedText.getOutputText();
     expect(previewText.length).toBeGreaterThan(0);
 
@@ -24,7 +24,7 @@ test.describe('6. Export Options and Controls', () => {
       .toContain(previewText.split('\n')[0]);
 
     await appPage.tabbedText.togglePreviewEdit(true);
-    await expect.poll(async () => appPage.tabbedText.getPreviewEditLabel()).toContain('Preview');
+    await appPage.tabbedText.expectPreviewEditLabelContains('Preview');
 
     expectNoPageErrors(pageErrors);
   });

--- a/apps/web/src/tests/browser/planned-functional/filtering-sorting/clear-filters.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/filtering-sorting/clear-filters.spec.js
@@ -3,16 +3,17 @@ const { openApp, seedRows, expectNoPageErrors, expect } = require('../helpers/sc
 
 test.describe('3. Filtering and Sorting', () => {
   test('Clear All Filters', async ({ page }) => {
+    const seededValues = ['Apple', 'Banana'];
     const { appPage, pageErrors } = await openApp(page);
-    const col = await seedRows(appPage, ['Apple', 'Banana']);
+    const col = await seedRows(appPage, seededValues);
 
     await appPage.gridEditor.setQuickFilter('Apple');
     await appPage.gridEditor.header.setColumnFilter(col, 'Apple');
     await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(1);
 
-    await appPage.gridEditor.clearFilters();
-    await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(2);
-    await expect.poll(async () => appPage.gridEditor.quickFilterInput.inputValue()).toBe('');
+    await appPage.gridEditor.clearFilters({ expectedActiveRowCount: seededValues.length });
+    await expect.poll(async () => appPage.gridEditor.renderer.countVisibleRows()).toBe(seededValues.length);
+    await expect(appPage.gridEditor.quickFilterInput).toHaveValue('');
 
     expectNoPageErrors(pageErrors);
   });

--- a/apps/web/src/tests/browser/planned-functional/filtering-sorting/column-sorting.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/filtering-sorting/column-sorting.spec.js
@@ -8,13 +8,13 @@ test.describe('3. Filtering and Sorting', () => {
 
     await appPage.gridEditor.header.sortAsc(col);
     await expect
-      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(col, 3))
+      .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(col, 3))
       .toEqual(['Apple', 'Banana', 'Cherry']);
     await expect.poll(async () => appPage.gridEditor.header.getColumnSortState(col)).toContain('asc');
 
     await appPage.gridEditor.header.sortDesc(col);
     await expect
-      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(col, 3))
+      .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(col, 3))
       .toEqual(['Cherry', 'Banana', 'Apple']);
     await expect.poll(async () => appPage.gridEditor.header.getColumnSortState(col)).toContain('desc');
 

--- a/apps/web/src/tests/browser/planned-functional/filtering-sorting/column-sorting.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/filtering-sorting/column-sorting.spec.js
@@ -8,13 +8,13 @@ test.describe('3. Filtering and Sorting', () => {
 
     await appPage.gridEditor.header.sortAsc(col);
     await expect
-      .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(col)).slice(0, 3))
+      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(col, 3))
       .toEqual(['Apple', 'Banana', 'Cherry']);
     await expect.poll(async () => appPage.gridEditor.header.getColumnSortState(col)).toContain('asc');
 
     await appPage.gridEditor.header.sortDesc(col);
     await expect
-      .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(col)).slice(0, 3))
+      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(col, 3))
       .toEqual(['Cherry', 'Banana', 'Apple']);
     await expect.poll(async () => appPage.gridEditor.header.getColumnSortState(col)).toContain('desc');
 

--- a/apps/web/src/tests/browser/planned-functional/grid-operations/clear-sort-before-add-rows-below.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/grid-operations/clear-sort-before-add-rows-below.spec.js
@@ -8,12 +8,12 @@ test.describe('1. Grid Basic Operations', () => {
 
     await appPage.gridEditor.header.sortDesc(columnName);
     await expect
-      .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(columnName)).slice(0, 4))
+      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(columnName, 4))
       .toEqual(['D', 'C', 'B', 'A']);
 
     await appPage.gridEditor.clearSort();
     await expect
-      .poll(async () => (await appPage.gridEditor.renderer.getColumnTextsByName(columnName)).slice(0, 4))
+      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(columnName, 4))
       .toEqual(['A', 'B', 'C', 'D']);
 
     await appPage.gridEditor.selectRows([1, 2]);

--- a/apps/web/src/tests/browser/planned-functional/grid-operations/clear-sort-before-add-rows-below.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/grid-operations/clear-sort-before-add-rows-below.spec.js
@@ -8,12 +8,12 @@ test.describe('1. Grid Basic Operations', () => {
 
     await appPage.gridEditor.header.sortDesc(columnName);
     await expect
-      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(columnName, 4))
+      .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(columnName, 4))
       .toEqual(['D', 'C', 'B', 'A']);
 
     await appPage.gridEditor.clearSort();
     await expect
-      .poll(async () => appPage.gridEditor.renderer.getTopVisibleColumnTextsByName(columnName, 4))
+      .poll(async () => appPage.gridEditor.renderer.getTopActiveColumnTextsByName(columnName, 4))
       .toEqual(['A', 'B', 'C', 'D']);
 
     await appPage.gridEditor.selectRows([1, 2]);

--- a/apps/web/src/tests/browser/planned-functional/helpers/scenario-helpers.js
+++ b/apps/web/src/tests/browser/planned-functional/helpers/scenario-helpers.js
@@ -20,7 +20,7 @@ async function ensureTextEditMode(appPage) {
   if (!enabled) {
     await appPage.tabbedText.togglePreviewEdit(true);
   }
-  await expect.poll(async () => appPage.importExportControls.isSetGridFromTextEnabled()).toBeTruthy();
+  await appPage.importExportControls.expectSetGridFromTextEnabled(true);
 }
 
 function expectNoPageErrors(pageErrors) {

--- a/apps/web/src/tests/browser/planned-functional/import-export/csv-file-upload.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/import-export/csv-file-upload.spec.js
@@ -14,7 +14,7 @@ test.describe('4. Import Export Basic', () => {
     try {
       await appPage.importExportControls.uploadFile(valid);
       await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBeGreaterThanOrEqual(2);
-      await expect.poll(async () => appPage.importExportControls.getProgressStatusText()).toContain('complete');
+      await appPage.importExportControls.expectProgressStatusContains('complete');
 
       const rowsBefore = await appPage.gridEditor.renderer.countRows();
       await appPage.importExportControls.uploadFile(path.resolve('README.md'));

--- a/apps/web/src/tests/browser/planned-functional/import-export/drag-drop-import.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/import-export/drag-drop-import.spec.js
@@ -15,7 +15,7 @@ test.describe('4. Import Export Basic', () => {
       await expect(appPage.importExportControls.dropZone).toBeVisible();
       await appPage.importExportControls.uploadFile(valid);
       await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBeGreaterThanOrEqual(2);
-      await expect.poll(async () => appPage.importExportControls.getProgressStatusText()).toContain('Import complete');
+      await appPage.importExportControls.expectProgressStatusContains('Import complete');
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
@@ -1,5 +1,5 @@
 const { test } = require('@playwright/test');
-const { openApp, seedRows, expectNoPageErrors, expect } = require('../helpers/scenario-helpers');
+const { openApp, seedRows, expectNoPageErrors } = require('../helpers/scenario-helpers');
 
 test.describe('4. Import Export Basic', () => {
   test('Set Text From Grid', async ({ page }) => {
@@ -7,12 +7,12 @@ test.describe('4. Import Export Basic', () => {
     await seedRows(appPage, ['A', 'B']);
 
     await appPage.tabbedText.selectFormat('CSV');
-    await expect.poll(async () => appPage.importExportControls.getExtensionLabel()).toBe('.csv');
+    await appPage.importExportControls.expectExtensionLabel('.csv');
     await appPage.importExportControls.setTextFromGrid();
 
-    await expect.poll(async () => appPage.tabbedText.getOutputText()).toContain('A');
-    await expect.poll(async () => appPage.tabbedText.getOutputText()).toContain('B');
-    await expect.poll(async () => appPage.tabbedText.getOutputText()).toContain('\n');
+    await appPage.tabbedText.expectOutputContains('A');
+    await appPage.tabbedText.expectOutputContains('B');
+    await appPage.tabbedText.expectOutputContains('\n');
 
     expectNoPageErrors(pageErrors);
   });

--- a/docs-src/blog/2026-05-10-import-and-amend-across-interfaces.md
+++ b/docs-src/blog/2026-05-10-import-and-amend-across-interfaces.md
@@ -1,0 +1,48 @@
+---
+slug: import-and-amend-across-interfaces
+title: "Import + Amend via Schema in API, CLI, and MCP"
+authors: [alan]
+tags: [release, feature, api, cli, mcp]
+date: 2026-05-10T09:30
+---
+
+The **Import + Amend via Schema** flow is now available across all automation interfaces: REST API, CLI, and MCP.
+
+You can now provide a schema plus existing input data, amend rows using schema rules, and get back the full resulting dataset in your requested output format.
+
+<!-- truncate -->
+
+## What Was Added
+
+- REST: `POST /v1/generate/amend`
+- CLI: `anywaydata amend --schema-file ... --data-file ... --input-format ...`
+- MCP: `amend_data_from_spec`
+
+All three share the same core behavior.
+
+## Behavior
+
+- `rowCount` defaults to imported row count.
+- If `rowCount` is smaller, only first `N` rows are amended.
+- Output always returns the full resulting dataset after amendment.
+- `stream` is accepted for compatibility but ignored for amend operations (buffered mode only).
+
+## Cross-Format Support
+
+The flow supports import and export across formats, including:
+
+- CSV input -> tab-delimited (`dsv`) output
+- tab-delimited (`dsv`) input -> CSV output
+
+## Why This Matters
+
+- You can automate the same amend workflow previously available in UI.
+- You can update existing datasets without rebuilding them from scratch.
+- You can keep the same schema-driven logic across UI, REST, CLI, and MCP.
+
+## Docs
+
+- [REST API](/docs/interfaces-and-deployment/rest-api)
+- [CLI (Node and Bun)](/docs/interfaces-and-deployment/cli-node-and-bun)
+- [MCP](/docs/interfaces-and-deployment/mcp)
+

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -146,6 +146,7 @@ Both endpoints generate data from the same schema language and output formats. T
 - if `rowCount` is provided and smaller, only first `N` rows are amended
 - output always returns the full resulting dataset
 - `stream` is accepted for compatibility and ignored
+- `inputFormat` is normalized (trimmed and lower-cased), so values like `" csv "` are accepted
 
 ## Schema Formatting
 
@@ -200,6 +201,28 @@ curl -X POST "http://localhost:3000/v1/generate/fromschema?outputFormat=markdown
   -H "Content-Type: text/plain" \
   --data-binary $'# markdown sample\n\nName\nBob\n\n# numeric id\nId\n1'
 ```
+
+Amend imported data (CSV input to tab-delimited output):
+
+```bash
+curl -X POST http://localhost:3000/v1/generate/amend \
+  -H "Content-Type: application/json" \
+  -d '{
+    "textSpec": "Name\nUpdated Name\nStatus\nActive",
+    "inputData": "\"Name\",\"Age\"\n\"Alice\",\"30\"\n\"Eve\",\"40\"\n",
+    "inputFormat": "csv",
+    "rowCount": 2,
+    "outputFormat": "dsv",
+    "responseFormat": "all",
+    "stream": true
+  }'
+```
+
+Notes for this example:
+
+- `stream` is ignored for amend and included only for compatibility.
+- `responseFormat: "all"` returns `headers`, `rows`, `rendered`, and `format`.
+- even when only part of the dataset is amended, the full resulting dataset is returned.
 
 Get current options for a format:
 

--- a/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
+++ b/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
@@ -106,3 +106,31 @@ Important:
 - `amend_data_from_spec` accepts `stream` for compatibility but ignores it (always buffered).
 - MCP does not expose OpenAPI/Swagger.
 - For HTTP/OpenAPI use cases, see [REST API](/docs/interfaces-and-deployment/rest-api).
+
+`amend_data_from_spec` behavior:
+
+- requires `textSpec`, `inputData`, and `inputFormat`
+- optional `rowCount` defaults to imported row count
+- if `rowCount` is smaller than imported rows, only first `N` rows are amended
+- output always includes the full resulting dataset
+
+Example `tools/call` payload:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 15,
+  "method": "tools/call",
+  "params": {
+    "name": "amend_data_from_spec",
+    "arguments": {
+      "textSpec": "Name\nUpdated Name\nStatus\nActive",
+      "inputData": "\"Name\",\"Age\"\n\"Alice\",\"30\"\n\"Eve\",\"40\"\n",
+      "inputFormat": "csv",
+      "rowCount": 2,
+      "outputFormat": "json",
+      "stream": true
+    }
+  }
+}
+```

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -68,6 +68,42 @@ Schema text supports:
 - Streaming is currently implemented for `csv` and `jsonl` exports. Other formats use buffered generation.
 - `amend` always uses buffered generation; stream flags are ignored for this command.
 - Auto-streaming (`--stream-threshold`) applies only when writing to a file. For stdout workflows, use `--stream` explicitly.
+- For `amend`, if `-n/--numberOfLines` is omitted, all imported rows are amended.
+- For `amend`, if `-n/--numberOfLines` is smaller than imported rows, only the first `N` rows are amended and full output is still returned.
+
+## Amend Examples
+
+CSV input to tab-delimited output:
+
+```bash
+anywaydata amend \
+  --schema-file schema.txt \
+  --data-file input.csv \
+  --input-format csv \
+  -f dsv
+```
+
+Tab-delimited input to CSV output file:
+
+```bash
+anywaydata amend \
+  --schema-file schema.txt \
+  --data-file input.dsv \
+  --input-format dsv \
+  -f csv \
+  -o amended.csv
+```
+
+Amend only first two rows:
+
+```bash
+anywaydata amend \
+  --schema-file schema.txt \
+  --data-file input.csv \
+  --input-format csv \
+  -n 2 \
+  -f json
+```
 
 Example `input.txt` schema file:
 

--- a/packages/core-ui/src/tests/utils/export-controls.test.js
+++ b/packages/core-ui/src/tests/utils/export-controls.test.js
@@ -14,6 +14,7 @@ describe('ExportControls', () => {
   let controls;
 
   beforeEach(() => {
+    jest.useRealTimers();
     dom = new JSDOM(`<!doctype html><html><body>
       <ul><li class="active-type"><a data-type="csv" href="#">CSV</a></li></ul>
       <button id="filedownload">Download</button>
@@ -37,6 +38,7 @@ describe('ExportControls', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
     dom.window.close();
   });
@@ -63,6 +65,7 @@ describe('ExportControls', () => {
   test('fileDownload exits when type is not exportable', async () => {
     exporter.canExport.mockReturnValue(false);
     const downloadSpy = jest.spyOn(Download.prototype, 'downloadFile').mockImplementation(() => {});
+    const statusSpy = jest.spyOn(controls, '_setExportProgressStatus');
     const button = document.getElementById('filedownload');
     const statusElem = document.getElementById('export-progress-status');
 
@@ -71,7 +74,8 @@ describe('ExportControls', () => {
 
     expect(exporter.getGridAs).not.toHaveBeenCalled();
     expect(downloadSpy).not.toHaveBeenCalled();
-    expect(statusElem.textContent).toContain('Export not available');
+    expect(statusSpy).toHaveBeenCalledWith('Export not available for this format.', false);
+    expect(statusElem.style.display).toBe('inline-block');
     expect(button.disabled).toBe(false);
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved browser tests and helpers to assert top active column values (first N active rows), wait for grid stability after sort/filter actions, and enhanced clear-filters behavior with expected-row checks, retries, and diagnostics — boosting test stability and reliability.
* **Documentation**
  * Published blog post and updated REST API, CLI, and MCP docs with the Import + Amend flow, examples, and updated defaults/behavior notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eviltester/grid-table-editor/pull/78)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->