### PR TITLE
more streaming output

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ Notes:
 - for JSON requests, newline characters inside string literals must be escaped as `\\n`
 - use `/v1/generate/fromschema` when you want to paste raw multiline text directly
 
+Streaming notes for generation:
+
+- stream mode supports: `csv`, `jsonl`, `dsv`, `json`, `xml`
+- `json` stream mode emits a valid JSON array payload
+- incompatible format options in stream mode are warned and ignored where needed
+
 OpenAPI spec:
 
 `GET http://localhost:3000/v1/openapi.json`

--- a/README.md
+++ b/README.md
@@ -359,11 +359,12 @@ Notes:
 - for JSON requests, newline characters inside string literals must be escaped as `\\n`
 - use `/v1/generate/fromschema` when you want to paste raw multiline text directly
 
-Streaming notes for generation:
+Streaming notes for CLI/core generation:
 
 - stream mode supports: `csv`, `jsonl`, `dsv`, `json`, `xml`
 - `json` stream mode emits a valid JSON array payload
 - incompatible format options in stream mode are warned and ignored where needed
+- REST API generation endpoints currently run in buffered mode
 
 OpenAPI spec:
 

--- a/apps/api/src/openapi.js
+++ b/apps/api/src/openapi.js
@@ -32,6 +32,8 @@ const openApiDocument = {
     '/v1/generate': {
       post: {
         summary: 'Generate data from text spec with selectable response shape',
+        description:
+          'Streaming generation is available for csv, jsonl, dsv, json and xml. In stream mode, incompatible format options are reported as warnings and ignored where needed.',
         requestBody: {
           required: true,
           content: {

--- a/apps/api/src/openapi.js
+++ b/apps/api/src/openapi.js
@@ -33,7 +33,7 @@ const openApiDocument = {
       post: {
         summary: 'Generate data from text spec with selectable response shape',
         description:
-          'Streaming generation is available for csv, jsonl, dsv, json and xml. In stream mode, incompatible format options are reported as warnings and ignored where needed.',
+          'Generation requests are currently processed in buffered mode for all formats. Stream-mode behavior is available in the core helper and CLI, not this REST endpoint.',
         requestBody: {
           required: true,
           content: {

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -83,8 +83,15 @@ Streaming is currently supported for:
 
 - `csv`
 - `jsonl`
+- `dsv`
+- `json`
+- `xml`
 
-Other formats use buffered generation.
+Notes:
+
+- `json` stream mode emits a valid JSON array payload.
+- For stream-mode option mismatches, generation continues and warnings are reported when applicable.
+- Other formats use buffered generation.
 
 For `amend`, streaming flags are accepted for compatibility but ignored (always buffered).
 
@@ -93,6 +100,9 @@ Examples:
 ```bash
 anywaydata generate -i ./apps/cli/examples/company-literal.txt -n 100000 -f jsonl -o output.jsonl --stream
 anywaydata generate -i ./apps/cli/examples/company-literal.txt -n 100000 -f csv -o output.csv --stream-threshold 1000
+anywaydata generate -i ./apps/cli/examples/company-literal.txt -n 100000 -f dsv -o output.dsv --stream
+anywaydata generate -i ./apps/cli/examples/company-literal.txt -n 100000 -f json -o output.json --stream
+anywaydata generate -i ./apps/cli/examples/company-literal.txt -n 100000 -f xml -o output.xml --stream
 ```
 
 ## Spec File Format

--- a/apps/cli/src/cli-options.js
+++ b/apps/cli/src/cli-options.js
@@ -37,7 +37,7 @@ export function parseCliOptions(argvInput = process.argv) {
     .option('stream', {
       type: 'boolean',
       default: false,
-      describe: 'Use streaming generation path when available (exporting CSV or JSONL)',
+      describe: 'Use streaming generation path when available (exporting CSV, JSONL, DSV, JSON or XML)',
     })
     .option('stream-threshold', {
       type: 'number',

--- a/apps/cli/src/run-cli.js
+++ b/apps/cli/src/run-cli.js
@@ -106,7 +106,7 @@ export async function runCliCommand({ options, platform }) {
     }
   }
 
-  if (useStreamMode && (outputFormat === 'csv' || outputFormat === 'jsonl')) {
+  if (useStreamMode && ['csv', 'jsonl', 'dsv', 'json', 'xml'].includes(outputFormat)) {
     const streamedLines = [];
     const writer = options.outputFile ? platform.createLineWriter(options.outputFile) : null;
     let writerClosed = false;
@@ -133,6 +133,11 @@ export async function runCliCommand({ options, platform }) {
       }
 
       progress(streamResult.diagnostics.report);
+      if (Array.isArray(streamResult.diagnostics?.warnings)) {
+        for (const warning of streamResult.diagnostics.warnings) {
+          progress(`WARNING: ${warning}`);
+        }
+      }
       if (options.testMode && streamResult.diagnostics.firstRow) {
         progress('e.g.');
         progress(JSON.stringify(streamResult.diagnostics.firstRow));

--- a/apps/cli/src/tests/integration.cli-params.test.js
+++ b/apps/cli/src/tests/integration.cli-params.test.js
@@ -102,28 +102,30 @@ test('param --show-progress false suppresses progress logs', () => {
   expect(result.stdout).toContain('"Company"');
 });
 
-test('params --stream and --show-progress true use streaming path for csv/jsonl', async () => {
+test('params --stream and --show-progress true use streaming path for csv/jsonl/dsv/json/xml', async () => {
   const inputPath = path.join(repoRoot, 'apps', 'cli', 'examples', 'company-literal.txt');
-  const outputPath = tempFile('stream');
-  const result = runCli([
-    'generate',
-    '-i',
-    inputPath,
-    '-n',
-    '2',
-    '-f',
-    'csv',
-    '-o',
-    outputPath,
-    '--stream',
-    '--show-progress',
-    'true',
-  ]);
-  expect(result.status).toBe(0);
-  expect(result.stdout).toContain('using stream mode');
-
-  const written = await fs.readFile(outputPath, 'utf8');
-  expect(written).toContain('"Company"');
+  const formats = ['csv', 'jsonl', 'dsv', 'json', 'xml'];
+  for (const format of formats) {
+    const outputPath = tempFile(`stream-${format}`);
+    const result = runCli([
+      'generate',
+      '-i',
+      inputPath,
+      '-n',
+      '2',
+      '-f',
+      format,
+      '-o',
+      outputPath,
+      '--stream',
+      '--show-progress',
+      'true',
+    ]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('using stream mode');
+    const written = await fs.readFile(outputPath, 'utf8');
+    expect(written.length).toBeGreaterThan(0);
+  }
 });
 
 test('param --stream-threshold auto-enables stream mode when threshold reached', () => {

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -148,11 +148,10 @@ Both endpoints generate data from the same schema language and output formats. T
 - `stream` is accepted for compatibility and ignored
 - `inputFormat` is normalized (trimmed and lower-cased), so values like `" csv "` are accepted
 
-Generation streaming behavior:
+Generation mode behavior:
 
-- stream mode supports: `csv`, `jsonl`, `dsv`, `json`, `xml`
-- `json` stream mode emits a valid JSON array payload
-- if stream mode cannot honor some format options, generation continues and warnings are reported
+- REST generation endpoints currently run in buffered mode.
+- Stream-mode generation behavior is available via the core helper/CLI paths, not via `/v1/generate`.
 
 ## Schema Formatting
 

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -148,6 +148,12 @@ Both endpoints generate data from the same schema language and output formats. T
 - `stream` is accepted for compatibility and ignored
 - `inputFormat` is normalized (trimmed and lower-cased), so values like `" csv "` are accepted
 
+Generation streaming behavior:
+
+- stream mode supports: `csv`, `jsonl`, `dsv`, `json`, `xml`
+- `json` stream mode emits a valid JSON array payload
+- if stream mode cannot honor some format options, generation continues and warnings are reported
+
 ## Schema Formatting
 
 Schema text supports:

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -44,7 +44,7 @@ Parameter guide for the examples:
 - `-o, --outputfile`: optional output file path. If omitted, output is written to stdout.
 - `-t, --testMode`: generate one row and print diagnostics for troubleshooting.
 - `--show-progress`: explicitly control progress logs (for example `--show-progress true` or `--show-progress false`).
-- `--stream`: enable streaming generation when supported (currently `csv` and `jsonl`).
+- `--stream`: enable streaming generation when supported (`csv`, `jsonl`, `dsv`, `json`, `xml`).
 - `--stream-threshold`: auto-enable streaming when `rowCount >= threshold` and `--outputfile` is set (default `5000`).
 - `--unsafe-faker-expressions`: opt-in to expression-style faker arguments (unsafe for untrusted input).
 - `--help`: show CLI usage and options.
@@ -65,7 +65,9 @@ Schema text supports:
   - on for stdout mode (no `--outputfile`)
   - on for `--testMode`
   - off for file output unless `--show-progress true` is provided
-- Streaming is currently implemented for `csv` and `jsonl` exports. Other formats use buffered generation.
+- Streaming is currently implemented for `csv`, `jsonl`, `dsv`, `json`, and `xml` exports. Other formats use buffered generation.
+- JSON stream mode emits a valid JSON array payload.
+- If a stream mode cannot honor some format options, generation continues and warnings are reported.
 - `amend` always uses buffered generation; stream flags are ignored for this command.
 - Auto-streaming (`--stream-threshold`) applies only when writing to a file. For stdout workflows, use `--stream` explicitly.
 - For `amend`, if `-n/--numberOfLines` is omitted, all imported rows are amended.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
     },
     "apps/api": {
       "name": "@anywaydata/api",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
-        "@anywaydata/core": "^1.1.0",
+        "@anywaydata/core": "^1.2.0",
         "express": "^4.21.2",
         "swagger-ui-express": "^5.0.1"
       },
@@ -48,9 +48,9 @@
     },
     "apps/cli": {
       "name": "@anywaydata/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@anywaydata/core": "^1.1.0",
+        "@anywaydata/core": "^1.2.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -59,9 +59,9 @@
     },
     "apps/mcp": {
       "name": "@anywaydata/mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
-        "@anywaydata/core": "^1.1.0"
+        "@anywaydata/core": "^1.2.0"
       },
       "bin": {
         "anywaydata-mcp": "src/index.js"
@@ -8928,7 +8928,7 @@
     },
     "packages/core": {
       "name": "@anywaydata/core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@faker-js/faker": "^9.7.0",
         "papaparse": "^5.5.2",
@@ -8939,7 +8939,7 @@
       "name": "@anywaydata/core-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@anywaydata/core": "^1.1.0"
+        "@anywaydata/core": "^1.2.0"
       }
     }
   },
@@ -8956,7 +8956,7 @@
     "@anywaydata/api": {
       "version": "file:apps/api",
       "requires": {
-        "@anywaydata/core": "^1.1.0",
+        "@anywaydata/core": "^1.2.0",
         "express": "^4.21.2",
         "swagger-ui-express": "^5.0.1"
       }
@@ -8964,7 +8964,7 @@
     "@anywaydata/cli": {
       "version": "file:apps/cli",
       "requires": {
-        "@anywaydata/core": "^1.1.0",
+        "@anywaydata/core": "^1.2.0",
         "yargs": "^17.7.2"
       }
     },
@@ -8979,13 +8979,13 @@
     "@anywaydata/core-ui": {
       "version": "file:packages/core-ui",
       "requires": {
-        "@anywaydata/core": "^1.1.0"
+        "@anywaydata/core": "^1.2.0"
       }
     },
     "@anywaydata/mcp": {
       "version": "file:apps/mcp",
       "requires": {
-        "@anywaydata/core": "^1.1.0"
+        "@anywaydata/core": "^1.2.0"
       }
     },
     "@babel/code-frame": {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -536,6 +536,15 @@ function getCsvStreamSettings(options = {}) {
   return { quoteChar, escapeChar, includeHeader };
 }
 
+function getDsvStreamSettings(options = {}) {
+  const delimiter = typeof options.delimiter === 'string' && options.delimiter.length > 0 ? options.delimiter : '\t';
+  const quoteChar = typeof options.quoteChar === 'string' && options.quoteChar.length > 0 ? options.quoteChar : '"';
+  const escapeChar =
+    typeof options.escapeChar === 'string' && options.escapeChar.length > 0 ? options.escapeChar : quoteChar;
+  const includeHeader = options.header !== false;
+  return { delimiter, quoteChar, escapeChar, includeHeader };
+}
+
 function quoteCsvValue(value, { quoteChar, escapeChar }) {
   const text = String(value ?? '');
   const escapedQuote = `${escapeChar}${quoteChar}`;
@@ -547,8 +556,150 @@ function rowToCsv(headers, row, csvSettings) {
   return headers.map((header) => quoteCsvValue(row[header], csvSettings)).join(',');
 }
 
+function rowToDsv(headers, row, dsvSettings) {
+  return headers.map((header) => quoteCsvValue(row[header], dsvSettings)).join(dsvSettings.delimiter);
+}
+
 function rowToJsonLine(row) {
   return JSON.stringify(row);
+}
+
+function rowArrayToObject(headers, rowArray, options = {}) {
+  const makeNumbersNumeric = options?.makeNumbersNumeric === true;
+  const rowObject = {};
+  for (let i = 0; i < headers.length; i += 1) {
+    const header = headers[i];
+    const value = rowArray[i] === undefined || rowArray[i] === null ? '' : rowArray[i];
+    if (makeNumbersNumeric) {
+      if (value * 1 == 0) {
+        rowObject[header] = 0;
+      } else {
+        rowObject[header] = value == value * 1 ? value * 1 : value;
+      }
+    } else {
+      rowObject[header] = value;
+    }
+  }
+  return rowObject;
+}
+
+function getUnsupportedStreamingOptionWarnings(outputFormat, options = {}) {
+  const warnings = [];
+  if (outputFormat === 'json') {
+    if (options.asObject === true) {
+      warnings.push('Streaming JSON ignores option asObject=true and always emits a JSON array.');
+    }
+    if (typeof options.asPropertyNamed === 'string' && options.asPropertyNamed.trim().length > 0) {
+      warnings.push('Streaming JSON ignores option asPropertyNamed and always emits a JSON array.');
+    }
+    if (options.prettyPrint === true || options.prettyPrintDelimiter !== undefined) {
+      warnings.push('Streaming JSON ignores prettyPrint options and emits compact JSON.');
+    }
+    if (options.outputAsJsonLines === true) {
+      warnings.push('Streaming JSON ignores outputAsJsonLines=true and emits a JSON array.');
+    }
+  }
+  return warnings;
+}
+
+function parseXmlAttributeColumns(attributeColumnsCsv) {
+  return String(attributeColumnsCsv ?? '')
+    .split(',')
+    .map((column) => column.trim())
+    .filter((column) => column.length > 0);
+}
+
+function normaliseXmlName(originalName, fallbackName, contextLabel, usedNames, warnings) {
+  const namesInUse = usedNames || new Set();
+  const inputName = String(originalName ?? '').trim();
+  let normalised = inputName.length > 0 ? inputName : fallbackName;
+  normalised = normalised.replace(/\s+/g, '_').replace(/[^A-Za-z0-9_.-]/g, '_');
+  if (!/^[A-Za-z_]/.test(normalised)) normalised = `_${normalised}`;
+  if (/^xml/i.test(normalised)) normalised = `_${normalised}`;
+  if (normalised.length === 0) normalised = fallbackName;
+  let deduplicated = normalised;
+  let suffix = 2;
+  while (namesInUse.has(deduplicated)) {
+    deduplicated = `${normalised}_${suffix}`;
+    suffix += 1;
+  }
+  namesInUse.add(deduplicated);
+  if (inputName !== deduplicated) {
+    warnings.push(`Auto-fixed XML ${contextLabel} name "${inputName}" -> "${deduplicated}"`);
+  }
+  return deduplicated;
+}
+
+function sanitizeXmlCharacters(value) {
+  const text = String(value ?? '');
+  let sanitized = '';
+  for (const char of text) {
+    const codePoint = char.codePointAt(0);
+    const isValidXmlChar =
+      codePoint === 0x9 ||
+      codePoint === 0xa ||
+      codePoint === 0xd ||
+      (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+    if (isValidXmlChar) sanitized += char;
+  }
+  return sanitized;
+}
+
+function escapeXmlValue(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function createXmlStreamContext(headers, options = {}, warnings = []) {
+  const includeXmlHeader = options.includeXmlHeader !== false;
+  const rootElementName = normaliseXmlName(options.rootElementName, 'root', 'root element', new Set(), warnings);
+  const itemElementName = normaliseXmlName(options.itemElementName, 'item', 'item element', new Set(), warnings);
+  const attributeColumnNames = parseXmlAttributeColumns(options.attributeColumnsCsv);
+  const knownAttributeColumnNames = new Set();
+  attributeColumnNames.forEach((attributeColumnName) => {
+    if (headers.includes(attributeColumnName)) {
+      knownAttributeColumnNames.add(attributeColumnName);
+    } else {
+      warnings.push(`Ignored unknown XML attribute column: ${attributeColumnName}`);
+    }
+  });
+  const usedColumnXmlNames = new Set();
+  const headerXmlNames = headers.map((header) => {
+    const context = knownAttributeColumnNames.has(header) ? 'attribute column' : 'child element column';
+    return normaliseXmlName(header, 'column', context, usedColumnXmlNames, warnings);
+  });
+  const xmlnsValue = String(options.xmlns ?? '').trim();
+  const xmlnsAttribute = xmlnsValue.length > 0 ? ` xmlns="${escapeXmlValue(xmlnsValue)}"` : '';
+  return {
+    includeXmlHeader,
+    rootElementName,
+    itemElementName,
+    knownAttributeColumnNames,
+    headerXmlNames,
+    xmlnsAttribute,
+  };
+}
+
+function rowToXmlItem(headers, headerXmlNames, rowArray, knownAttributeColumnNames, itemElementName) {
+  const itemAttributes = [];
+  const childElements = [];
+  headers.forEach((header, columnIndex) => {
+    const value = sanitizeXmlCharacters(rowArray[columnIndex]);
+    const xmlName = headerXmlNames[columnIndex];
+    if (knownAttributeColumnNames.has(header)) {
+      itemAttributes.push(`${xmlName}="${escapeXmlValue(value)}"`);
+      return;
+    }
+    childElements.push(`    <${xmlName}>${escapeXmlValue(value)}</${xmlName}>`);
+  });
+  const attributesSuffix = itemAttributes.length > 0 ? ` ${itemAttributes.join(' ')}` : '';
+  return [`  <${itemElementName}${attributesSuffix}>`, ...childElements, `  </${itemElementName}>`].join('\n');
 }
 
 export async function streamFromTextSpec({
@@ -589,12 +740,12 @@ export async function streamFromTextSpec({
     };
   }
 
-  if (outputFormat !== 'csv' && outputFormat !== 'jsonl') {
+  if (!['csv', 'jsonl', 'dsv', 'json', 'xml'].includes(outputFormat)) {
     return {
       ok: false,
-      errors: ['Streaming currently supports only csv and jsonl formats.'],
+      errors: ['Streaming currently supports only csv, jsonl, dsv, json and xml formats.'],
       diagnostics: {
-        supportedStreamingFormats: ['csv', 'jsonl'],
+        supportedStreamingFormats: ['csv', 'jsonl', 'dsv', 'json', 'xml'],
       },
     };
   }
@@ -605,24 +756,60 @@ export async function streamFromTextSpec({
   let firstRow = null;
   const report = generator.compilationReport();
   const csvSettings = outputFormat === 'csv' ? getCsvStreamSettings(options) : null;
+  const dsvSettings = outputFormat === 'dsv' ? getDsvStreamSettings(options) : null;
+  const diagnosticsWarnings = getUnsupportedStreamingOptionWarnings(outputFormat, options);
+  const xmlContext = outputFormat === 'xml' ? createXmlStreamContext(headers, options, diagnosticsWarnings) : null;
 
   if (outputFormat === 'csv' && csvSettings.includeHeader) {
     await onChunk(headers.map((header) => quoteCsvValue(header, csvSettings)).join(','));
   }
+  if (outputFormat === 'dsv' && dsvSettings.includeHeader) {
+    await onChunk(headers.map((header) => quoteCsvValue(header, dsvSettings)).join(dsvSettings.delimiter));
+  }
+  if (outputFormat === 'json') {
+    await onChunk('[');
+  }
+  if (outputFormat === 'xml') {
+    if (xmlContext.includeXmlHeader) {
+      await onChunk('<?xml version="1.0" encoding="utf-8"?>');
+    }
+    await onChunk(`<${xmlContext.rootElementName}${xmlContext.xmlnsAttribute}>`);
+  }
 
   for (let index = 0; index < safeRowCount; index += 1) {
-    const row = generator.generateRow();
+    const rowArray = generator.generateRow();
     if (firstRow === null) {
-      firstRow = row;
+      firstRow = rowArray;
     }
     if (rows) {
-      rows.push(row);
+      rows.push(rowArray);
     }
     if (outputFormat === 'csv') {
-      await onChunk(rowToCsv(headers, row, csvSettings));
-    } else {
-      await onChunk(rowToJsonLine(row));
+      await onChunk(rowToCsv(headers, rowArray, csvSettings));
+    } else if (outputFormat === 'dsv') {
+      await onChunk(rowToDsv(headers, rowArray, dsvSettings));
+    } else if (outputFormat === 'jsonl') {
+      await onChunk(rowToJsonLine(rowArray));
+    } else if (outputFormat === 'json') {
+      const rowObject = rowArrayToObject(headers, rowArray, options);
+      await onChunk(index === 0 ? JSON.stringify(rowObject) : `,${JSON.stringify(rowObject)}`);
+    } else if (outputFormat === 'xml') {
+      await onChunk(
+        rowToXmlItem(
+          headers,
+          xmlContext.headerXmlNames,
+          rowArray,
+          xmlContext.knownAttributeColumnNames,
+          xmlContext.itemElementName
+        )
+      );
     }
+  }
+  if (outputFormat === 'json') {
+    await onChunk(']');
+  }
+  if (outputFormat === 'xml') {
+    await onChunk(`</${xmlContext.rootElementName}>`);
   }
 
   return {
@@ -637,6 +824,7 @@ export async function streamFromTextSpec({
       streamed: true,
       firstRow,
       collectRows,
+      warnings: diagnosticsWarnings,
     },
   };
 }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -553,15 +553,16 @@ function quoteCsvValue(value, { quoteChar, escapeChar }) {
 }
 
 function rowToCsv(headers, row, csvSettings) {
-  return headers.map((header) => quoteCsvValue(row[header], csvSettings)).join(',');
+  return headers.map((_, index) => quoteCsvValue(row[index], csvSettings)).join(',');
 }
 
 function rowToDsv(headers, row, dsvSettings) {
-  return headers.map((header) => quoteCsvValue(row[header], dsvSettings)).join(dsvSettings.delimiter);
+  return headers.map((_, index) => quoteCsvValue(row[index], dsvSettings)).join(dsvSettings.delimiter);
 }
 
-function rowToJsonLine(row) {
-  return JSON.stringify(row);
+function rowToJsonLine(headers, rowArray, options = {}) {
+  const rowObject = rowArrayToObject(headers, rowArray, options);
+  return JSON.stringify(rowObject);
 }
 
 function rowArrayToObject(headers, rowArray, options = {}) {
@@ -571,10 +572,13 @@ function rowArrayToObject(headers, rowArray, options = {}) {
     const header = headers[i];
     const value = rowArray[i] === undefined || rowArray[i] === null ? '' : rowArray[i];
     if (makeNumbersNumeric) {
-      if (value * 1 == 0) {
-        rowObject[header] = 0;
+      const text = String(value);
+      if (text.trim().length === 0) {
+        rowObject[header] = value;
+      } else if (Number.isFinite(Number(text))) {
+        rowObject[header] = Number(text);
       } else {
-        rowObject[header] = value == value * 1 ? value * 1 : value;
+        rowObject[header] = value;
       }
     } else {
       rowObject[header] = value;
@@ -789,7 +793,7 @@ export async function streamFromTextSpec({
     } else if (outputFormat === 'dsv') {
       await onChunk(rowToDsv(headers, rowArray, dsvSettings));
     } else if (outputFormat === 'jsonl') {
-      await onChunk(rowToJsonLine(rowArray));
+      await onChunk(rowToJsonLine(headers, rowArray, options));
     } else if (outputFormat === 'json') {
       const rowObject = rowArrayToObject(headers, rowArray, options);
       await onChunk(index === 0 ? JSON.stringify(rowObject) : `,${JSON.stringify(rowObject)}`);

--- a/packages/core/src/tests/core-api/streamFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/streamFromTextSpec.test.js
@@ -38,12 +38,12 @@ test('streamFromTextSpec rejects unsupported formats', async () => {
   const result = await streamFromTextSpec({
     textSpec: 'Name\nBob',
     rowCount: 2,
-    outputFormat: 'json',
+    outputFormat: 'markdown',
     onChunk: async () => {},
   });
 
   expect(result.ok).toBe(false);
-  expect(result.errors[0]).toContain('supports only csv and jsonl');
+  expect(result.errors[0]).toContain('supports only csv, jsonl, dsv, json and xml');
 });
 
 test('streamFromTextSpec rejects pairwise mode', async () => {
@@ -57,4 +57,72 @@ test('streamFromTextSpec rejects pairwise mode', async () => {
 
   expect(result.ok).toBe(false);
   expect(result.errors[0]).toContain('does not support pairwise');
+});
+
+test('streamFromTextSpec streams dsv rows with delimiter and header', async () => {
+  const chunks = [];
+  const result = await streamFromTextSpec({
+    textSpec: 'Name\nBob',
+    rowCount: 2,
+    outputFormat: 'dsv',
+    options: { delimiter: '\t', header: true },
+    onChunk: async (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+  expect(result.ok).toBe(true);
+  expect(chunks.length).toBe(3);
+  expect(chunks[0]).toContain('"Name"');
+});
+
+test('streamFromTextSpec streams json as valid array payload', async () => {
+  const chunks = [];
+  const result = await streamFromTextSpec({
+    textSpec: 'Name\nBob',
+    rowCount: 2,
+    outputFormat: 'json',
+    onChunk: async (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+  expect(result.ok).toBe(true);
+  const payload = chunks.join('');
+  const parsed = JSON.parse(payload);
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBe(2);
+  expect(parsed[0]).toHaveProperty('Name');
+});
+
+test('streamFromTextSpec streams xml as a well-formed document', async () => {
+  const chunks = [];
+  const result = await streamFromTextSpec({
+    textSpec: 'Name\nBob',
+    rowCount: 2,
+    outputFormat: 'xml',
+    onChunk: async (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+  expect(result.ok).toBe(true);
+  const payload = chunks.join('\n');
+  expect(payload).toContain('<?xml version="1.0" encoding="utf-8"?>');
+  expect(payload).toContain('<root>');
+  expect(payload).toContain('</root>');
+  expect(payload).toContain('<item>');
+});
+
+test('streamFromTextSpec warns for json options that are unsupported in stream mode', async () => {
+  const result = await streamFromTextSpec({
+    textSpec: 'Name\nBob',
+    rowCount: 1,
+    outputFormat: 'json',
+    options: {
+      asObject: true,
+      outputAsJsonLines: true,
+    },
+    onChunk: async () => {},
+  });
+  expect(result.ok).toBe(true);
+  expect(Array.isArray(result.diagnostics.warnings)).toBe(true);
+  expect(result.diagnostics.warnings.join(' ')).toContain('ignores option asObject');
 });

--- a/packages/core/src/tests/core-api/streamFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/streamFromTextSpec.test.js
@@ -14,6 +14,8 @@ test('streamFromTextSpec streams csv rows with header', async () => {
   expect(result.ok).toBe(true);
   expect(chunks.length).toBe(3);
   expect(chunks[0]).toContain('"Name"');
+  expect(chunks[1]).toContain('"Bob"');
+  expect(chunks[2]).toContain('"Bob"');
 });
 
 test('streamFromTextSpec streams jsonl rows', async () => {
@@ -30,7 +32,10 @@ test('streamFromTextSpec streams jsonl rows', async () => {
   expect(result.ok).toBe(true);
   expect(chunks.length).toBe(2);
   for (const chunk of chunks) {
-    expect(() => JSON.parse(chunk)).not.toThrow();
+    const parsed = JSON.parse(chunk);
+    expect(Array.isArray(parsed)).toBe(false);
+    expect(parsed).toHaveProperty('Name');
+    expect(parsed.Name).toBe('Bob');
   }
 });
 
@@ -73,6 +78,8 @@ test('streamFromTextSpec streams dsv rows with delimiter and header', async () =
   expect(result.ok).toBe(true);
   expect(chunks.length).toBe(3);
   expect(chunks[0]).toContain('"Name"');
+  expect(chunks[1]).toContain('"Bob"');
+  expect(chunks[2]).toContain('"Bob"');
 });
 
 test('streamFromTextSpec streams json as valid array payload', async () => {
@@ -91,6 +98,8 @@ test('streamFromTextSpec streams json as valid array payload', async () => {
   expect(Array.isArray(parsed)).toBe(true);
   expect(parsed.length).toBe(2);
   expect(parsed[0]).toHaveProperty('Name');
+  expect(parsed[0].Name).toBe('Bob');
+  expect(parsed[1].Name).toBe('Bob');
 });
 
 test('streamFromTextSpec streams xml as a well-formed document', async () => {
@@ -109,6 +118,7 @@ test('streamFromTextSpec streams xml as a well-formed document', async () => {
   expect(payload).toContain('<root>');
   expect(payload).toContain('</root>');
   expect(payload).toContain('<item>');
+  expect(payload).toContain('<Name>Bob</Name>');
 });
 
 test('streamFromTextSpec warns for json options that are unsupported in stream mode', async () => {
@@ -125,4 +135,21 @@ test('streamFromTextSpec warns for json options that are unsupported in stream m
   expect(result.ok).toBe(true);
   expect(Array.isArray(result.diagnostics.warnings)).toBe(true);
   expect(result.diagnostics.warnings.join(' ')).toContain('ignores option asObject');
+});
+
+test('streamFromTextSpec json makeNumbersNumeric preserves empty strings', async () => {
+  const chunks = [];
+  const result = await streamFromTextSpec({
+    textSpec: 'Quantity\n()',
+    rowCount: 1,
+    outputFormat: 'json',
+    options: { makeNumbersNumeric: true },
+    onChunk: async (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+
+  expect(result.ok).toBe(true);
+  const parsed = JSON.parse(chunks.join(''));
+  expect(parsed[0].Quantity).toBe('');
 });


### PR DESCRIPTION
closes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming generation now supports DSV, JSON, and XML in addition to CSV and JSONL
  * CLI progress now surfaces streaming warnings during generation

* **Documentation**
  * API and CLI docs updated: JSON streaming emits a valid JSON array; REST generation endpoints remain buffered; incompatible stream options produce warnings and are ignored

* **Tests**
  * Expanded CLI and core streaming tests covering new formats and warning behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eviltester/grid-table-editor/pull/82)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->