### PR TITLE
96 enhancement   auto populate preview checkbox

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -59,7 +59,6 @@
           <li>Select multiple rows with ctrl and shift (cmd + shift on mac)</li>
           <li>Add new Rows with the [Add Row...] buttons</li>
           <li>[Delete Selected Rows] will delete any selected rows</li>
-          <li>Use the filter icon on the left of each column to filter specific column.</li>
           <li>The up and down arrows in the header will sort the column, use (x) to clear the sort</li>
           <li>Use the Filter field to filter any column to match the text</li>
           <li>[Clear Filters] will clear the quick filter and all column filters</li>

--- a/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
@@ -110,12 +110,20 @@ class TabbedTextComponent {
     await this.autoPreviewCheckbox.uncheck();
   }
 
-  async expectAutoPreviewEnabled(enabled = true) {
-    if (enabled) {
+  async expectAutoPreviewInteractive(interactive = true) {
+    if (interactive) {
       await expect(this.autoPreviewCheckbox).toBeEnabled();
       return;
     }
     await expect(this.autoPreviewCheckbox).toBeDisabled();
+  }
+
+  async expectAutoPreviewChecked(checked = true) {
+    if (checked) {
+      await expect(this.autoPreviewCheckbox).toBeChecked();
+      return;
+    }
+    await expect(this.autoPreviewCheckbox).not.toBeChecked();
   }
 
   async expectOutputContains(value) {

--- a/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/tabbed-text.component.js
@@ -7,6 +7,7 @@ class TabbedTextComponent {
     this.tabsList = page.locator('#tabbedTextArea .conversionTypesList');
     this.outputTextArea = page.locator('#tabbedTextArea textarea.textrepresentation').first();
     this.previewOrEditButton = page.locator('#previewEditModeButton');
+    this.autoPreviewCheckbox = page.locator('#autoPreviewCheckbox');
     this.copyButton = page.locator('#copyTextButton');
     this.subtasks = page.locator('#conversionSubtasks');
 
@@ -37,6 +38,7 @@ class TabbedTextComponent {
     await expect(this.container).toBeVisible();
     await expect(this.tabsList).toBeVisible();
     await expect(this.copyButton).toBeVisible();
+    await expect(this.autoPreviewCheckbox).toBeVisible();
   }
 
   async expectReady() {
@@ -98,6 +100,22 @@ class TabbedTextComponent {
 
   async getOutputText() {
     return this.outputTextArea.inputValue();
+  }
+
+  async setAutoPreview(enabled = true) {
+    if (enabled) {
+      await this.autoPreviewCheckbox.check();
+      return;
+    }
+    await this.autoPreviewCheckbox.uncheck();
+  }
+
+  async expectAutoPreviewEnabled(enabled = true) {
+    if (enabled) {
+      await expect(this.autoPreviewCheckbox).toBeEnabled();
+      return;
+    }
+    await expect(this.autoPreviewCheckbox).toBeDisabled();
   }
 
   async expectOutputContains(value) {

--- a/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
@@ -23,13 +23,15 @@ test.describe('4. Import Export Basic', () => {
 
     await appPage.tabbedText.selectFormat('CSV');
     await appPage.tabbedText.setAutoPreview(true);
-    await appPage.tabbedText.expectAutoPreviewEnabled(true);
+    await appPage.tabbedText.expectAutoPreviewInteractive(true);
+    await appPage.tabbedText.expectAutoPreviewChecked(true);
 
     await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 0, 'A-updated');
     await appPage.tabbedText.expectOutputContains('A-updated');
 
     await appPage.tabbedText.togglePreviewEdit(true);
-    await appPage.tabbedText.expectAutoPreviewEnabled(false);
+    await appPage.tabbedText.expectAutoPreviewInteractive(false);
+    await appPage.tabbedText.expectAutoPreviewChecked(true);
     await appPage.tabbedText.setOutputText('manual-text');
 
     await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 1, 'B-updated');

--- a/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/import-export/set-text-from-grid.spec.js
@@ -1,4 +1,4 @@
-const { test } = require('@playwright/test');
+const { test, expect } = require('@playwright/test');
 const { openApp, seedRows, expectNoPageErrors } = require('../helpers/scenario-helpers');
 
 test.describe('4. Import Export Basic', () => {
@@ -13,6 +13,27 @@ test.describe('4. Import Export Basic', () => {
     await appPage.tabbedText.expectOutputContains('A');
     await appPage.tabbedText.expectOutputContains('B');
     await appPage.tabbedText.expectOutputContains('\n');
+
+    expectNoPageErrors(pageErrors);
+  });
+
+  test('Auto Preview updates text on grid edits in preview mode and is disabled in edit mode', async ({ page }) => {
+    const { appPage, pageErrors } = await openApp(page);
+    const primaryColumnName = await seedRows(appPage, ['A', 'B']);
+
+    await appPage.tabbedText.selectFormat('CSV');
+    await appPage.tabbedText.setAutoPreview(true);
+    await appPage.tabbedText.expectAutoPreviewEnabled(true);
+
+    await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 0, 'A-updated');
+    await appPage.tabbedText.expectOutputContains('A-updated');
+
+    await appPage.tabbedText.togglePreviewEdit(true);
+    await appPage.tabbedText.expectAutoPreviewEnabled(false);
+    await appPage.tabbedText.setOutputText('manual-text');
+
+    await appPage.gridEditor.renderer.setCellTextByColumnName(primaryColumnName, 1, 'B-updated');
+    await expect(appPage.tabbedText.outputTextArea).toHaveValue('manual-text');
 
     expectNoPageErrors(pageErrors);
   });

--- a/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/gridExtension-ag-grid.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/gridExtension-ag-grid.js
@@ -78,7 +78,7 @@ class GridExtensionAgGrid {
   }
 
   // given an array of String column names, set the grid to have those columns
-  createColumns(columnNames) {
+  createColumns(columnNames, { notify = true } = {}) {
     let colDefs = [];
     let fieldId = this.getNextFieldNumber();
     columnNames.forEach((column) => {
@@ -89,7 +89,9 @@ class GridExtensionAgGrid {
     this.gridApi.setGridOption('columnDefs', colDefs);
     var fieldNames = colDefs.map((colDef) => colDef.field);
     this.addFieldsToData(fieldNames, '');
-    this._notifyGridChanged();
+    if (notify) {
+      this._notifyGridChanged();
+    }
   }
 
   addFieldsToData(fieldNames, defaultValue) {
@@ -469,7 +471,7 @@ class GridExtensionAgGrid {
       // TODO : report errors on screen
     }
 
-    this.createColumns(dataTable.getHeaders());
+    this.createColumns(dataTable.getHeaders(), { notify: false });
     this.gridApi.setGridOption('rowData', []);
 
     let addRows = [];

--- a/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/gridExtension-ag-grid.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/gridExtension-ag-grid.js
@@ -9,6 +9,7 @@ import { GenericDataTable } from '@anywaydata/core/data_formats/generic-data-tab
 class GridExtensionAgGrid {
   constructor(gridApi) {
     this.gridApi = gridApi;
+    this._gridChangedCallbacks = new Set();
     this.cellRendererText = (params) => {
       let val = params.value;
       if (val && val.replaceAll) {
@@ -27,6 +28,7 @@ class GridExtensionAgGrid {
     ];
     this.gridApi.setGridOption('columnDefs', columnDefs);
     this.gridApi.setGridOption('rowData', []);
+    this._notifyGridChanged();
   }
 
   clearFilters() {
@@ -87,6 +89,7 @@ class GridExtensionAgGrid {
     this.gridApi.setGridOption('columnDefs', colDefs);
     var fieldNames = colDefs.map((colDef) => colDef.field);
     this.addFieldsToData(fieldNames, '');
+    this._notifyGridChanged();
   }
 
   addFieldsToData(fieldNames, defaultValue) {
@@ -132,6 +135,7 @@ class GridExtensionAgGrid {
     this.gridApi.setGridOption('columnDefs', colDefs);
 
     this.addFieldToData(newCol.field, '');
+    this._notifyGridChanged();
 
     return newCol;
   }
@@ -206,6 +210,7 @@ class GridExtensionAgGrid {
     });
 
     this.gridApi.setGridOption('columnDefs', newColDefs);
+    this._notifyGridChanged();
 
     // TODO : consider deleting all the data as well
   }
@@ -297,6 +302,7 @@ class GridExtensionAgGrid {
       }
     }
 
+    this._notifyGridChanged();
     return { noSelectedRows: false, amendedRows: targetNodes.length };
   }
 
@@ -329,10 +335,12 @@ class GridExtensionAgGrid {
     });
     editColDef.headerName = name;
     this.gridApi.setGridOption('columnDefs', colDefs);
+    this._notifyGridChanged();
   }
 
   deleteSelectedRows() {
     this.gridApi.applyTransaction({ remove: this.gridApi.getSelectedRows() });
+    this._notifyGridChanged();
   }
 
   getBlankRowData() {
@@ -346,6 +354,7 @@ class GridExtensionAgGrid {
 
   addRow() {
     this.gridApi.applyTransaction({ add: [this.getBlankRowData()] });
+    this._notifyGridChanged();
   }
 
   addRowsRelativeToSelection(position) {
@@ -379,6 +388,7 @@ class GridExtensionAgGrid {
     }
 
     this.gridApi.applyTransaction({ add: objectsToAdd, addIndex: positionIndexToAddAt });
+    this._notifyGridChanged();
   }
 
   // calculate the max row index from a selection of rows
@@ -472,6 +482,31 @@ class GridExtensionAgGrid {
 
     // TODO : apply transactions incrementally for larger data sets
     this.gridApi.applyTransaction({ add: addRows });
+    this._notifyGridChanged();
+  }
+
+  onGridChanged(callback) {
+    if (typeof callback !== 'function') {
+      return () => {};
+    }
+    this._gridChangedCallbacks.add(callback);
+    return () => {
+      this._gridChangedCallbacks.delete(callback);
+    };
+  }
+
+  notifyGridChanged() {
+    this._notifyGridChanged();
+  }
+
+  _notifyGridChanged() {
+    this._gridChangedCallbacks.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.error('Grid change callback failed', error);
+      }
+    });
   }
 
   _nodeToRowValues(node, fieldnames) {

--- a/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/main-display-grid.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/main-display-grid.js
@@ -50,6 +50,9 @@ class ExtendedDataGrid {
         headerCheckbox: false,
         enableClickSelection: true,
       },
+      onCellValueChanged: () => {
+        this.gridExtras?.notifyGridChanged?.();
+      },
       //onColumnResized: (params) => {params.api.resetRowHeights();}
     };
   }

--- a/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/main-display-grid.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/ag-grid/main-display-grid.js
@@ -53,6 +53,14 @@ class ExtendedDataGrid {
       onCellValueChanged: () => {
         this.gridExtras?.notifyGridChanged?.();
       },
+      onRowDragEnd: () => {
+        this.gridExtras?.notifyGridChanged?.();
+      },
+      onColumnMoved: (params) => {
+        if (params?.finished) {
+          this.gridExtras?.notifyGridChanged?.();
+        }
+      },
       //onColumnResized: (params) => {params.api.resetRowHeights();}
     };
   }

--- a/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
@@ -17,7 +17,6 @@ class GridExtensionTabulator {
     this.tabulator = tabulator;
     this.tabUtils = new TabulatorHelper(tabulator);
     this._pendingGridMutation = Promise.resolve();
-    this._gridChangedCallbacks = new Set();
 
     if (typeof this.tabulator?.on === 'function') {
       this.tabulator.on('cellEdited', () => this._notifyGridChanged());
@@ -968,20 +967,31 @@ class GridExtensionTabulator {
     if (typeof callback !== 'function') {
       return () => {};
     }
-    this._gridChangedCallbacks.add(callback);
+    const callbacks = this._getSharedGridChangedCallbacks();
+    callbacks.add(callback);
     return () => {
-      this._gridChangedCallbacks.delete(callback);
+      callbacks.delete(callback);
     };
   }
 
   _notifyGridChanged() {
-    this._gridChangedCallbacks.forEach((callback) => {
+    this._getSharedGridChangedCallbacks().forEach((callback) => {
       try {
         callback();
       } catch (error) {
         console.error('Grid change callback failed', error);
       }
     });
+  }
+
+  _getSharedGridChangedCallbacks() {
+    if (!this.tabulator) {
+      return new Set();
+    }
+    if (!this.tabulator.__gridChangedCallbacks) {
+      this.tabulator.__gridChangedCallbacks = new Set();
+    }
+    return this.tabulator.__gridChangedCallbacks;
   }
 }
 

--- a/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
@@ -18,10 +18,7 @@ class GridExtensionTabulator {
     this.tabUtils = new TabulatorHelper(tabulator);
     this._pendingGridMutation = Promise.resolve();
 
-    if (typeof this.tabulator?.on === 'function') {
-      this.tabulator.on('cellEdited', () => this._notifyGridChanged());
-      this.tabulator.on('rowMoved', () => this._notifyGridChanged());
-    }
+    this._bindSharedGridChangeEventListeners();
 
     // this.cellRendererText = (params) => {
     //     let val = params.value;
@@ -35,10 +32,11 @@ class GridExtensionTabulator {
   // [x] convert to tabulature
   clearGrid() {
     const columnDefs = [{ title: '~rename-me', field: 'column1' }];
-    this._enqueueGridMutation(() => {
+    return this._enqueueGridMutation(() => {
       return Promise.resolve(this.tabulator.setColumns(columnDefs)).then(() => this.tabulator.setData([]));
+    }).then(() => {
+      this._notifyGridChanged();
     });
-    this._notifyGridChanged();
   }
 
   // [x] convert to tabulature
@@ -131,6 +129,7 @@ class GridExtensionTabulator {
     }
 
     await this._copyColumnData(column.getDefinition().field, destinationCol.field);
+    this._notifyGridChanged();
   }
 
   appendColumnToGrid(colTitle) {
@@ -156,6 +155,7 @@ class GridExtensionTabulator {
 
     const targetId = this._normaliseId(id);
     resolvedColumn.move(targetId, moveToAfter);
+    this._notifyGridChanged();
   }
 
   // [x] convert to tabulature
@@ -992,6 +992,48 @@ class GridExtensionTabulator {
       this.tabulator.__gridChangedCallbacks = new Set();
     }
     return this.tabulator.__gridChangedCallbacks;
+  }
+
+  _bindSharedGridChangeEventListeners() {
+    if (!this.tabulator || typeof this.tabulator.on !== 'function') {
+      return;
+    }
+    if (this.tabulator.__gridChangedEventsBound === true) {
+      return;
+    }
+
+    const handlers = {
+      cellEdited: () => this._notifyGridChanged(),
+      rowMoved: () => this._notifyGridChanged(),
+      columnMoved: () => this._notifyGridChanged(),
+    };
+    this.tabulator.__gridChangedEventHandlers = handlers;
+    this.tabulator.on('cellEdited', handlers.cellEdited);
+    this.tabulator.on('rowMoved', handlers.rowMoved);
+    this.tabulator.on('columnMoved', handlers.columnMoved);
+    this.tabulator.__gridChangedEventsBound = true;
+  }
+
+  destroy() {
+    if (!this.tabulator || typeof this.tabulator.off !== 'function') {
+      return;
+    }
+    const handlers = this.tabulator.__gridChangedEventHandlers;
+    if (!handlers) {
+      return;
+    }
+
+    if (typeof handlers.cellEdited === 'function') {
+      this.tabulator.off('cellEdited', handlers.cellEdited);
+    }
+    if (typeof handlers.rowMoved === 'function') {
+      this.tabulator.off('rowMoved', handlers.rowMoved);
+    }
+    if (typeof handlers.columnMoved === 'function') {
+      this.tabulator.off('columnMoved', handlers.columnMoved);
+    }
+    this.tabulator.__gridChangedEventsBound = false;
+    delete this.tabulator.__gridChangedEventHandlers;
   }
 }
 

--- a/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
@@ -17,6 +17,12 @@ class GridExtensionTabulator {
     this.tabulator = tabulator;
     this.tabUtils = new TabulatorHelper(tabulator);
     this._pendingGridMutation = Promise.resolve();
+    this._gridChangedCallbacks = new Set();
+
+    if (typeof this.tabulator?.on === 'function') {
+      this.tabulator.on('cellEdited', () => this._notifyGridChanged());
+      this.tabulator.on('rowMoved', () => this._notifyGridChanged());
+    }
 
     // this.cellRendererText = (params) => {
     //     let val = params.value;
@@ -33,6 +39,7 @@ class GridExtensionTabulator {
     this._enqueueGridMutation(() => {
       return Promise.resolve(this.tabulator.setColumns(columnDefs)).then(() => this.tabulator.setData([]));
     });
+    this._notifyGridChanged();
   }
 
   // [x] convert to tabulature
@@ -89,6 +96,7 @@ class GridExtensionTabulator {
     this.tabulator.setColumns(colDefs);
     var fieldNames = colDefs.map((colDef) => colDef.field);
     this._addFieldsToData(fieldNames, '');
+    this._notifyGridChanged();
   }
 
   _addFieldsToData(fieldNames, defaultValue) {
@@ -131,6 +139,7 @@ class GridExtensionTabulator {
     this.tabulator.addColumn(newCol, false);
 
     this._addFieldToData(newCol.field, '');
+    this._notifyGridChanged();
 
     return newCol;
   }
@@ -165,6 +174,7 @@ class GridExtensionTabulator {
       addToLeft = false;
     }
     this.tabulator.addColumn(column, addToLeft, resolvedExistingColumn);
+    this._notifyGridChanged();
     return column;
   }
 
@@ -180,6 +190,7 @@ class GridExtensionTabulator {
       return;
     }
     column.delete();
+    this._notifyGridChanged();
   }
 
   deleteColumnId(id) {
@@ -295,6 +306,7 @@ class GridExtensionTabulator {
     });
 
     this._refreshTableAfterBulkMutation();
+    this._notifyGridChanged();
 
     return { noSelectedRows: false, amendedRows: targetRows.length };
   }
@@ -331,6 +343,7 @@ class GridExtensionTabulator {
       return;
     }
     column.updateDefinition({ title: name });
+    this._notifyGridChanged();
   }
 
   renameColId(id, name) {
@@ -341,6 +354,7 @@ class GridExtensionTabulator {
   deleteSelectedRows() {
     const rows = this.tabulator.getSelectedRows();
     this.tabulator.deleteRow(rows);
+    this._notifyGridChanged();
   }
 
   // [x] convert to tabulature
@@ -356,6 +370,7 @@ class GridExtensionTabulator {
   // [x] convert to tabulature
   addRow() {
     this.tabUtils.addRowToBottom(this._getBlankRowData());
+    this._notifyGridChanged();
   }
 
   // [x] convert to tabulature
@@ -368,9 +383,11 @@ class GridExtensionTabulator {
       // and there are no rows then add to top
       if (this.tabulator.getDataCount() == 0 || position < 0) {
         this.tabUtils.addRowToTop(this._getBlankRowData());
+        this._notifyGridChanged();
         return;
       } else {
         this.tabUtils.addRowToBottom(this._getBlankRowData());
+        this._notifyGridChanged();
         return;
       }
     }
@@ -393,6 +410,7 @@ class GridExtensionTabulator {
       addAbove = false;
     }
     this.tabulator.addData(objectsToAdd, addAbove, relativeToRow);
+    this._notifyGridChanged();
   }
 
   // calculate the max row from a selection of rows
@@ -532,6 +550,7 @@ class GridExtensionTabulator {
 
       this._applyHeaderTitles(headers);
       await this._autoFitFirstColumn();
+      this._notifyGridChanged();
     });
 
     // TODO : apply transactions incrementally for larger data sets
@@ -943,6 +962,26 @@ class GridExtensionTabulator {
     if (typeof this.tabulator.redraw === 'function') {
       this.tabulator.redraw(true);
     }
+  }
+
+  onGridChanged(callback) {
+    if (typeof callback !== 'function') {
+      return () => {};
+    }
+    this._gridChangedCallbacks.add(callback);
+    return () => {
+      this._gridChangedCallbacks.delete(callback);
+    };
+  }
+
+  _notifyGridChanged() {
+    this._gridChangedCallbacks.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.error('Grid change callback failed', error);
+      }
+    });
   }
 }
 

--- a/packages/core-ui/js/gui_components/import-export-controls.js
+++ b/packages/core-ui/js/gui_components/import-export-controls.js
@@ -18,6 +18,7 @@ class ImportExportControls {
     this._hasBoundPreviewTextInput = false;
     this.autoPreviewEnabled = false;
     this._hasBoundAutoPreviewInput = false;
+    this._gridChangeUnsubscribe = null;
   }
 
   addHTMLtoGui(parentelement) {
@@ -73,10 +74,14 @@ class ImportExportControls {
   }
 
   setGridChangeSource(gridChangeSource) {
+    if (typeof this._gridChangeUnsubscribe === 'function') {
+      this._gridChangeUnsubscribe();
+      this._gridChangeUnsubscribe = null;
+    }
     if (!gridChangeSource || typeof gridChangeSource.onGridChanged !== 'function') {
       return;
     }
-    gridChangeSource.onGridChanged(() => {
+    this._gridChangeUnsubscribe = gridChangeSource.onGridChanged(() => {
       this._maybeAutoPreviewFromGridChange();
     });
   }

--- a/packages/core-ui/js/gui_components/import-export-controls.js
+++ b/packages/core-ui/js/gui_components/import-export-controls.js
@@ -584,7 +584,6 @@ class ImportExportControls {
     const isPreviewMode = this.isPreviewTextMode();
     autoPreviewCheckbox.disabled = !isPreviewMode;
     autoPreviewCheckbox.checked = this.autoPreviewEnabled;
-    autoPreviewCheckbox.setAttribute('aria-disabled', autoPreviewCheckbox.disabled ? 'true' : 'false');
   }
 
   _setPreviewTextDirty(isDirty) {

--- a/packages/core-ui/js/gui_components/import-export-controls.js
+++ b/packages/core-ui/js/gui_components/import-export-controls.js
@@ -16,6 +16,8 @@ class ImportExportControls {
     this.currentOptionsPanelWidthPx = null;
     this._activeSplitDrag = null;
     this._hasBoundPreviewTextInput = false;
+    this.autoPreviewEnabled = false;
+    this._hasBoundAutoPreviewInput = false;
   }
 
   addHTMLtoGui(parentelement) {
@@ -70,6 +72,15 @@ class ImportExportControls {
     this.exportControls.addHooksToPage(document);
   }
 
+  setGridChangeSource(gridChangeSource) {
+    if (!gridChangeSource || typeof gridChangeSource.onGridChanged !== 'function') {
+      return;
+    }
+    gridChangeSource.onGridChanged(() => {
+      this._maybeAutoPreviewFromGridChange();
+    });
+  }
+
   getExportControls() {
     return this.exportControls;
   }
@@ -101,6 +112,16 @@ class ImportExportControls {
       return;
     }
     this.exportControls.renderTextFromGrid();
+  }
+
+  _maybeAutoPreviewFromGridChange() {
+    if (!this.isPreviewTextMode()) {
+      return;
+    }
+    if (!this.autoPreviewEnabled) {
+      return;
+    }
+    this.renderTextFromGrid();
   }
 
   loadFile() {
@@ -509,11 +530,13 @@ class ImportExportControls {
 
   _syncGridFromTextButtonState() {
     this._bindPreviewTextInputIfAvailable();
+    this._bindAutoPreviewCheckboxIfAvailable();
     const importButton = document.querySelector('#setgridfromtextbutton');
     if (!importButton) {
       return;
     }
     importButton.disabled = this.isPreviewTextMode() ? !this.previewTextDirty : false;
+    this._syncAutoPreviewControlState();
   }
 
   _bindPreviewTextInputIfAvailable() {
@@ -531,6 +554,37 @@ class ImportExportControls {
       this._setPreviewTextDirty(true);
     });
     this._hasBoundPreviewTextInput = true;
+  }
+
+  _bindAutoPreviewCheckboxIfAvailable() {
+    if (this._hasBoundAutoPreviewInput) {
+      return;
+    }
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    if (!autoPreviewCheckbox) {
+      return;
+    }
+
+    autoPreviewCheckbox.addEventListener('change', (event) => {
+      this.autoPreviewEnabled = event?.currentTarget?.checked === true;
+      this._syncAutoPreviewControlState();
+      if (this.autoPreviewEnabled && this.isPreviewTextMode()) {
+        this.renderTextFromGrid();
+      }
+    });
+    this._hasBoundAutoPreviewInput = true;
+  }
+
+  _syncAutoPreviewControlState() {
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    if (!autoPreviewCheckbox) {
+      return;
+    }
+
+    const isPreviewMode = this.isPreviewTextMode();
+    autoPreviewCheckbox.disabled = !isPreviewMode;
+    autoPreviewCheckbox.checked = this.autoPreviewEnabled;
+    autoPreviewCheckbox.setAttribute('aria-disabled', autoPreviewCheckbox.disabled ? 'true' : 'false');
   }
 
   _setPreviewTextDirty(isDirty) {

--- a/packages/core-ui/js/gui_components/tabbed-text-control.js
+++ b/packages/core-ui/js/gui_components/tabbed-text-control.js
@@ -41,6 +41,10 @@ class TabbedTextControl {
             </ul>
           </div>
           <div class="rightbuttons">
+            <label id="autoPreviewLabel" class="auto-preview-control">
+              <input type="checkbox" id="autoPreviewCheckbox" />
+              Auto Preview
+            </label>
             <span
               title="Preview/Edit mode help"
               id="previewEditModeHelpIcon"

--- a/packages/core-ui/js/script.js
+++ b/packages/core-ui/js/script.js
@@ -45,6 +45,7 @@ async function bootstrapApp({
   importer = new ImporterClass(mainDataGrid.getGridExtras());
   importExportController.setExporter(exporter);
   importExportController.setImporter(importer);
+  importExportController.setGridChangeSource?.(mainDataGrid.getGridExtras());
 
   importExportController.renderTextFromGrid();
   importExportController.setFileFormatType();

--- a/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
+++ b/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
@@ -58,9 +58,15 @@ describe('GridExtensionTabulator duplicate column', () => {
   test('destroy unregisters shared tabulator grid-change listeners', () => {
     const tabulator = createTabulatorStub();
     const extension = new GridExtensionTabulator(tabulator);
-    const cellEditedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'cellEdited')?.[1];
-    const rowMovedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'rowMoved')?.[1];
-    const columnMovedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'columnMoved')?.[1];
+    const cellEditedCall = tabulator.on.mock.calls.find((call) => call[0] === 'cellEdited');
+    const rowMovedCall = tabulator.on.mock.calls.find((call) => call[0] === 'rowMoved');
+    const columnMovedCall = tabulator.on.mock.calls.find((call) => call[0] === 'columnMoved');
+    expect(cellEditedCall).toBeDefined();
+    expect(rowMovedCall).toBeDefined();
+    expect(columnMovedCall).toBeDefined();
+    const cellEditedHandler = cellEditedCall[1];
+    const rowMovedHandler = rowMovedCall[1];
+    const columnMovedHandler = columnMovedCall[1];
 
     extension.destroy();
 

--- a/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
+++ b/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
@@ -58,13 +58,16 @@ describe('GridExtensionTabulator duplicate column', () => {
   test('destroy unregisters shared tabulator grid-change listeners', () => {
     const tabulator = createTabulatorStub();
     const extension = new GridExtensionTabulator(tabulator);
+    const cellEditedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'cellEdited')?.[1];
+    const rowMovedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'rowMoved')?.[1];
+    const columnMovedHandler = tabulator.on.mock.calls.find((call) => call[0] === 'columnMoved')?.[1];
 
     extension.destroy();
 
     expect(tabulator.off).toHaveBeenCalledTimes(3);
-    expect(tabulator.off).toHaveBeenNthCalledWith(1, 'cellEdited', expect.any(Function));
-    expect(tabulator.off).toHaveBeenNthCalledWith(2, 'rowMoved', expect.any(Function));
-    expect(tabulator.off).toHaveBeenNthCalledWith(3, 'columnMoved', expect.any(Function));
+    expect(tabulator.off).toHaveBeenNthCalledWith(1, 'cellEdited', cellEditedHandler);
+    expect(tabulator.off).toHaveBeenNthCalledWith(2, 'rowMoved', rowMovedHandler);
+    expect(tabulator.off).toHaveBeenNthCalledWith(3, 'columnMoved', columnMovedHandler);
   });
 
   test('copies source column values into duplicate column', async () => {

--- a/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
+++ b/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
@@ -37,11 +37,36 @@ function createTabulatorStub() {
     setData(rows) {
       this._rowData = rows.map((row) => ({ ...row }));
     },
+    on: jest.fn(),
+    off: jest.fn(),
     redraw() {},
   };
 }
 
 describe('GridExtensionTabulator duplicate column', () => {
+  test('binds tabulator change listeners only once per table across wrapper instances', () => {
+    const tabulator = createTabulatorStub();
+    new GridExtensionTabulator(tabulator);
+    new GridExtensionTabulator(tabulator);
+
+    expect(tabulator.on).toHaveBeenCalledTimes(3);
+    expect(tabulator.on).toHaveBeenNthCalledWith(1, 'cellEdited', expect.any(Function));
+    expect(tabulator.on).toHaveBeenNthCalledWith(2, 'rowMoved', expect.any(Function));
+    expect(tabulator.on).toHaveBeenNthCalledWith(3, 'columnMoved', expect.any(Function));
+  });
+
+  test('destroy unregisters shared tabulator grid-change listeners', () => {
+    const tabulator = createTabulatorStub();
+    const extension = new GridExtensionTabulator(tabulator);
+
+    extension.destroy();
+
+    expect(tabulator.off).toHaveBeenCalledTimes(3);
+    expect(tabulator.off).toHaveBeenNthCalledWith(1, 'cellEdited', expect.any(Function));
+    expect(tabulator.off).toHaveBeenNthCalledWith(2, 'rowMoved', expect.any(Function));
+    expect(tabulator.off).toHaveBeenNthCalledWith(3, 'columnMoved', expect.any(Function));
+  });
+
   test('copies source column values into duplicate column', async () => {
     const tabulator = createTabulatorStub();
     const extension = new GridExtensionTabulator(tabulator);

--- a/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
+++ b/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
@@ -25,6 +25,7 @@ describe('ImportExportControls preview/edit mode', () => {
   beforeEach(() => {
     dom = new JSDOM(`<!doctype html><html><body>
             <ul><li class="active-type"><a data-type="csv" href="#">CSV</a></li></ul>
+            <label id="autoPreviewLabel"><input type="checkbox" id="autoPreviewCheckbox"/>Auto Preview</label>
             <textarea id="markdownarea"></textarea>
             <div id="importExportRoot"></div>
         </body></html>`);
@@ -109,6 +110,75 @@ describe('ImportExportControls preview/edit mode', () => {
     textArea.value = 'a,b\n1,2';
     textArea.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
     expect(button.disabled).toBe(false);
+  });
+
+  test('Auto Preview defaults unchecked and is enabled in preview mode', () => {
+    controls._syncGridFromTextButtonState();
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    expect(autoPreviewCheckbox.checked).toBe(false);
+    expect(autoPreviewCheckbox.disabled).toBe(false);
+  });
+
+  test('Auto Preview checkbox is disabled in edit mode', () => {
+    controls.toggleTextEditMode();
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    expect(autoPreviewCheckbox.disabled).toBe(true);
+  });
+
+  test('grid change auto-renders preview when Auto Preview is enabled in preview mode', () => {
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    autoPreviewCheckbox.checked = true;
+    autoPreviewCheckbox.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    const renderSpy = jest.spyOn(controls, 'renderTextFromGrid').mockImplementation(() => {});
+    controls._maybeAutoPreviewFromGridChange();
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('enabling Auto Preview immediately refreshes preview text from grid', () => {
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    const renderSpy = jest.spyOn(controls, 'renderTextFromGrid').mockImplementation(() => {});
+
+    autoPreviewCheckbox.checked = true;
+    autoPreviewCheckbox.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('grid change does not auto-render when Auto Preview is disabled', () => {
+    const renderSpy = jest.spyOn(controls, 'renderTextFromGrid').mockImplementation(() => {});
+    controls._maybeAutoPreviewFromGridChange();
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+
+  test('grid change does not auto-render in edit mode even when Auto Preview is enabled', () => {
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    autoPreviewCheckbox.checked = true;
+    autoPreviewCheckbox.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    controls.toggleTextEditMode();
+    const renderSpy = jest.spyOn(controls, 'renderTextFromGrid').mockImplementation(() => {});
+    controls._maybeAutoPreviewFromGridChange();
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+
+  test('setGridChangeSource subscribes and auto-renders on callbacks', () => {
+    const callbacks = [];
+    const source = {
+      onGridChanged: jest.fn((cb) => {
+        callbacks.push(cb);
+      }),
+    };
+    const autoPreviewCheckbox = document.getElementById('autoPreviewCheckbox');
+    autoPreviewCheckbox.checked = true;
+    autoPreviewCheckbox.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    const renderSpy = jest.spyOn(controls, 'renderTextFromGrid').mockImplementation(() => {});
+
+    controls.setGridChangeSource(source);
+    expect(source.onGridChanged).toHaveBeenCalledTimes(1);
+
+    callbacks[0]();
+    expect(renderSpy).toHaveBeenCalledTimes(1);
   });
 
   test('Set Grid From Text input listener binds when textarea is added after controls', () => {
@@ -239,6 +309,7 @@ describe('ImportExportControls file reading and visibility', () => {
   beforeEach(() => {
     dom = new JSDOM(`<!doctype html><html><body>
             <ul><li class="active-type"><a data-type="csv" href="#">CSV</a></li></ul>
+            <label id="autoPreviewLabel"><input type="checkbox" id="autoPreviewCheckbox"/>Auto Preview</label>
             <textarea id="markdownarea"></textarea>
             <div id="markdown"></div>
             <div class="edit-area"></div>

--- a/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
+++ b/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
@@ -181,6 +181,59 @@ describe('ImportExportControls preview/edit mode', () => {
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('tabulator grid-change callbacks are shared across wrapper instances for same table', () => {
+    const tabulatorTable = {};
+    const callbacksFromFirst = [];
+    const callbacksFromSecond = [];
+
+    const firstWrapperLike = {
+      tabulator: tabulatorTable,
+      _getSharedGridChangedCallbacks() {
+        if (!this.tabulator.__gridChangedCallbacks) {
+          this.tabulator.__gridChangedCallbacks = new Set();
+        }
+        return this.tabulator.__gridChangedCallbacks;
+      },
+      onGridChanged(callback) {
+        const callbacks = this._getSharedGridChangedCallbacks();
+        callbacks.add(callback);
+        callbacksFromFirst.push(callback);
+      },
+      _notifyGridChanged() {
+        this._getSharedGridChangedCallbacks().forEach((callback) => callback());
+      },
+    };
+
+    const secondWrapperLike = {
+      tabulator: tabulatorTable,
+      _getSharedGridChangedCallbacks() {
+        if (!this.tabulator.__gridChangedCallbacks) {
+          this.tabulator.__gridChangedCallbacks = new Set();
+        }
+        return this.tabulator.__gridChangedCallbacks;
+      },
+      onGridChanged(callback) {
+        const callbacks = this._getSharedGridChangedCallbacks();
+        callbacks.add(callback);
+        callbacksFromSecond.push(callback);
+      },
+      _notifyGridChanged() {
+        this._getSharedGridChangedCallbacks().forEach((callback) => callback());
+      },
+    };
+
+    const spyA = jest.fn();
+    const spyB = jest.fn();
+    firstWrapperLike.onGridChanged(spyA);
+    secondWrapperLike.onGridChanged(spyB);
+
+    secondWrapperLike._notifyGridChanged();
+    expect(spyA).toHaveBeenCalledTimes(1);
+    expect(spyB).toHaveBeenCalledTimes(1);
+    expect(callbacksFromFirst[0]).toBe(spyA);
+    expect(callbacksFromSecond[0]).toBe(spyB);
+  });
+
   test('Set Grid From Text input listener binds when textarea is added after controls', () => {
     const lateDom = new JSDOM(`<!doctype html><html><body>
             <ul><li class="active-type"><a data-type="csv" href="#">CSV</a></li></ul>

--- a/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
+++ b/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { ImportExportControls } from '../../../js/gui_components/import-export-controls.js';
 import { GenericDataTable } from '@anywaydata/core/data_formats/generic-data-table.js';
+import { GridExtension as GridExtensionTabulator } from '../../../js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js';
 
 function makeDataTable(rowCount) {
   const table = new GenericDataTable();
@@ -15,6 +16,12 @@ async function flushAsyncWork() {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createSharedTabulatorTableStub() {
+  return {
+    on: jest.fn(),
+  };
 }
 
 describe('ImportExportControls preview/edit mode', () => {
@@ -181,57 +188,35 @@ describe('ImportExportControls preview/edit mode', () => {
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('setGridChangeSource unsubscribes previous listener before re-subscribing', () => {
+    const firstUnsubscribe = jest.fn();
+    const secondUnsubscribe = jest.fn();
+    const firstSource = { onGridChanged: jest.fn(() => firstUnsubscribe) };
+    const secondSource = { onGridChanged: jest.fn(() => secondUnsubscribe) };
+
+    controls.setGridChangeSource(firstSource);
+    expect(firstSource.onGridChanged).toHaveBeenCalledTimes(1);
+    expect(firstUnsubscribe).not.toHaveBeenCalled();
+
+    controls.setGridChangeSource(secondSource);
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(secondSource.onGridChanged).toHaveBeenCalledTimes(1);
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+  });
+
   test('tabulator grid-change callbacks are shared across wrapper instances for same table', () => {
-    const tabulatorTable = {};
-    const callbacksFromFirst = [];
-    const callbacksFromSecond = [];
-
-    const firstWrapperLike = {
-      tabulator: tabulatorTable,
-      _getSharedGridChangedCallbacks() {
-        if (!this.tabulator.__gridChangedCallbacks) {
-          this.tabulator.__gridChangedCallbacks = new Set();
-        }
-        return this.tabulator.__gridChangedCallbacks;
-      },
-      onGridChanged(callback) {
-        const callbacks = this._getSharedGridChangedCallbacks();
-        callbacks.add(callback);
-        callbacksFromFirst.push(callback);
-      },
-      _notifyGridChanged() {
-        this._getSharedGridChangedCallbacks().forEach((callback) => callback());
-      },
-    };
-
-    const secondWrapperLike = {
-      tabulator: tabulatorTable,
-      _getSharedGridChangedCallbacks() {
-        if (!this.tabulator.__gridChangedCallbacks) {
-          this.tabulator.__gridChangedCallbacks = new Set();
-        }
-        return this.tabulator.__gridChangedCallbacks;
-      },
-      onGridChanged(callback) {
-        const callbacks = this._getSharedGridChangedCallbacks();
-        callbacks.add(callback);
-        callbacksFromSecond.push(callback);
-      },
-      _notifyGridChanged() {
-        this._getSharedGridChangedCallbacks().forEach((callback) => callback());
-      },
-    };
+    const tabulatorTable = createSharedTabulatorTableStub();
+    const firstWrapper = new GridExtensionTabulator(tabulatorTable);
+    const secondWrapper = new GridExtensionTabulator(tabulatorTable);
 
     const spyA = jest.fn();
     const spyB = jest.fn();
-    firstWrapperLike.onGridChanged(spyA);
-    secondWrapperLike.onGridChanged(spyB);
+    firstWrapper.onGridChanged(spyA);
+    secondWrapper.onGridChanged(spyB);
 
-    secondWrapperLike._notifyGridChanged();
+    secondWrapper._notifyGridChanged();
     expect(spyA).toHaveBeenCalledTimes(1);
     expect(spyB).toHaveBeenCalledTimes(1);
-    expect(callbacksFromFirst[0]).toBe(spyA);
-    expect(callbacksFromSecond[0]).toBe(spyB);
   });
 
   test('Set Grid From Text input listener binds when textarea is added after controls', () => {

--- a/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
+++ b/packages/core-ui/src/tests/utils/tabbed-text-control-mode.test.js
@@ -33,7 +33,12 @@ describe('TabbedTextControl preview/edit button', () => {
 
     const modeButton = host.querySelector('#previewEditModeButton');
     const modeHelpIcon = host.querySelector('#previewEditModeHelpIcon');
+    const autoPreviewLabel = host.querySelector('#autoPreviewLabel');
     expect(modeHelpIcon).not.toBeNull();
+    expect(autoPreviewLabel).not.toBeNull();
+    expect(
+      autoPreviewLabel.compareDocumentPosition(modeHelpIcon) & dom.window.Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     modeHelpIcon._tippy = { setContent: jest.fn() };
     tabs._syncPreviewEditButtonLabel();
     expect(modeButton.innerText).toBe('Preview (10)');


### PR DESCRIPTION
closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Auto Preview" checkbox to automatically update preview text when the grid changes; remains disabled in edit mode.

* **Integrations**
  * Grid now emits change notifications so other UI components can react to edits and trigger previews.

* **Documentation**
  * Updated in-app instructions: removed the per-column filter bullet and corrected the instruction list ordering/formatting.

* **Tests**
  * Added and expanded tests for auto-preview behavior, grid-change notifications, listener lifecycle, and UI ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eviltester/grid-table-editor/pull/97)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->