### PR TITLE
data editor changes - surface enum, literal, regex - no sorting

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -109,10 +109,7 @@
     </div>
 
     <!-- loading message -->
-    <p style="font-size: xx-large" id="initial-load">Please Wait, Loading Libraries...</p>
+    <p id="initial-load" role="status" aria-live="polite">Please Wait, Loading Libraries...</p>
 
-    <script>
-      document.getElementById('initial-load')?.remove();
-    </script>
   </body>
 </html>

--- a/apps/web/src/tests/browser/abstraction-smoke-tests/test-data-panel-smoke.spec.js
+++ b/apps/web/src/tests/browser/abstraction-smoke-tests/test-data-panel-smoke.spec.js
@@ -49,10 +49,9 @@ test('test data panel generates rows from faker and regex schema', async ({ page
   }
 
   await appPage.testDataPanel.setSchemaCell(0, 'columnName', 'Name');
-  await appPage.testDataPanel.setSchemaTypeValue(0, 'faker');
-  await appPage.testDataPanel.setSchemaCell(0, 'value', 'faker.person.fullName');
+  await appPage.testDataPanel.setSchemaTypeValue(0, 'person.fullName');
   await appPage.testDataPanel.setSchemaCell(1, 'columnName', 'Code');
-  await appPage.testDataPanel.setSchemaTypeValue(1, 'RegEx');
+  await appPage.testDataPanel.setSchemaTypeValue(1, 'regex');
   await appPage.testDataPanel.setSchemaCell(1, 'value', '[A-Z]{3}');
 
   await appPage.testDataPanel.clickGenerate();
@@ -83,7 +82,7 @@ test('embedded schema grid editing syncs to schema text and generates data', asy
 
   const targetRow = initialSchemaRows;
   await appPage.testDataPanel.setSchemaCell(targetRow, 'columnName', 'Code');
-  await appPage.testDataPanel.setSchemaTypeValue(targetRow, 'RegEx');
+  await appPage.testDataPanel.setSchemaTypeValue(targetRow, 'regex');
   await appPage.testDataPanel.setSchemaCell(targetRow, 'value', '[A-Z]{3}');
 
   await expect.poll(async () => appPage.testDataPanel.getSchemaText()).toContain('Code');

--- a/apps/web/src/tests/browser/abstractions/components/test-data-panel.component.js
+++ b/apps/web/src/tests/browser/abstractions/components/test-data-panel.component.js
@@ -128,7 +128,6 @@ class TestDataPanelComponent {
 
     if (await editor.locator('xpath=self::select').count()) {
       await editor.selectOption(String(value));
-      await editor.press('Enter');
     } else {
       await editor.fill(String(value));
       await editor.press('Enter');

--- a/apps/web/src/tests/browser/planned-functional/test-data/basic-generation.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/test-data/basic-generation.spec.js
@@ -14,8 +14,7 @@ test.describe('7. Test Data Generation', () => {
 
     const schemaRowIndex = beforeSchema;
     await appPage.testDataPanel.setSchemaCell(schemaRowIndex, 'columnName', 'First Name');
-    await appPage.testDataPanel.setSchemaTypeValue(schemaRowIndex, 'faker');
-    await appPage.testDataPanel.setSchemaCell(schemaRowIndex, 'value', 'faker.person.firstName');
+    await appPage.testDataPanel.setSchemaTypeValue(schemaRowIndex, 'person.firstName');
     await appPage.testDataPanel.setGenerateCount(5);
 
     await appPage.testDataPanel.clickGenerate();

--- a/apps/web/src/tests/browser/planned-functional/test-data/multiple-columns.spec.js
+++ b/apps/web/src/tests/browser/planned-functional/test-data/multiple-columns.spec.js
@@ -13,8 +13,7 @@ test.describe('7. Test Data Generation', () => {
     await expect.poll(async () => appPage.testDataPanel.getSchemaRowCount()).toBe(beforeSchema + 1);
 
     await appPage.testDataPanel.setSchemaCell(0, 'columnName', 'First Name');
-    await appPage.testDataPanel.setSchemaTypeValue(0, 'faker');
-    await appPage.testDataPanel.setSchemaCell(0, 'value', 'faker.person.firstName');
+    await appPage.testDataPanel.setSchemaTypeValue(0, 'person.firstName');
     await appPage.testDataPanel.addSchemaRow();
     await expect.poll(async () => appPage.testDataPanel.getSchemaRowCount()).toBe(beforeSchema + 2);
     await appPage.testDataPanel.setSchemaCell(1, 'columnName', 'Status');

--- a/packages/core-ui/js/gui_components/data-generator-page.js
+++ b/packages/core-ui/js/gui_components/data-generator-page.js
@@ -778,10 +778,10 @@ enum(active,inactive,pending)</pre>
                 </div>
                 <input type="text" data-field="name" placeholder="Column Name" value="${this.escapeHtml(row.name)}">
                 <select data-field="sourceType">
-                    <option value="${SOURCE_TYPE_FAKER}" ${row.sourceType === SOURCE_TYPE_FAKER ? 'selected' : ''}>faker</option>
-                    <option value="${SOURCE_TYPE_REGEX}" ${row.sourceType === SOURCE_TYPE_REGEX ? 'selected' : ''}>regex</option>
-                    <option value="${SOURCE_TYPE_LITERAL}" ${row.sourceType === SOURCE_TYPE_LITERAL ? 'selected' : ''}>literal</option>
                     <option value="${SOURCE_TYPE_ENUM}" ${row.sourceType === SOURCE_TYPE_ENUM ? 'selected' : ''}>enum</option>
+                    <option value="${SOURCE_TYPE_LITERAL}" ${row.sourceType === SOURCE_TYPE_LITERAL ? 'selected' : ''}>literal</option>
+                    <option value="${SOURCE_TYPE_REGEX}" ${row.sourceType === SOURCE_TYPE_REGEX ? 'selected' : ''}>regex</option>
+                    <option value="${SOURCE_TYPE_FAKER}" ${row.sourceType === SOURCE_TYPE_FAKER ? 'selected' : ''}>faker</option>
                 </select>
                 ${
                   isFakerSource

--- a/packages/core-ui/js/gui_components/testdatadefn.js
+++ b/packages/core-ui/js/gui_components/testdatadefn.js
@@ -597,6 +597,7 @@ function tabulatorTypeSelectEditor(cell, onRendered, success, cancel) {
   const editor = document.createElement('select');
   editor.style.width = '100%';
   editor.style.boxSizing = 'border-box';
+  let completed = false;
 
   const values = getTabulatorTypeEditorValues();
   values.forEach((entry) => {
@@ -616,23 +617,22 @@ function tabulatorTypeSelectEditor(cell, onRendered, success, cancel) {
     editor.focus();
   });
 
-  editor.addEventListener('change', () => {
+  const finishEdit = () => {
+    if (completed) {
+      return;
+    }
     const selectedValue = String(editor.value ?? '').trim();
     if (selectedValue === FAKER_SECTION_VALUE) {
+      completed = true;
       cancel();
       return;
     }
+    completed = true;
     success(selectedValue);
-  });
+  };
 
-  editor.addEventListener('blur', () => {
-    const selectedValue = String(editor.value ?? '').trim();
-    if (selectedValue === FAKER_SECTION_VALUE) {
-      cancel();
-      return;
-    }
-    success(selectedValue);
-  });
+  editor.addEventListener('change', finishEdit);
+  editor.addEventListener('blur', finishEdit);
 
   return editor;
 }
@@ -834,7 +834,7 @@ function normalizeEnumRuleDefinition(value) {
   if (rawValue.length === 0) {
     return '';
   }
-  if (/^enum\s*\(/i.test(rawValue)) {
+  if (/^(enum|datatype\.enum|awd\.datatype\.enum)\s*\(/i.test(rawValue)) {
     return rawValue;
   }
   return `enum(${rawValue})`;

--- a/packages/core-ui/js/gui_components/testdatadefn.js
+++ b/packages/core-ui/js/gui_components/testdatadefn.js
@@ -504,8 +504,11 @@ function populateTestDataGridFromRules() {
     } else if (rule.type == 'enum') {
       data.type = 'enum';
       data.value = rule.ruleSpec;
+    } else if (rule.type == 'literal') {
+      data.type = 'literal';
+      data.value = rule.ruleSpec;
     } else {
-      data.type = 'RegEx';
+      data.type = 'regex';
       data.value = rule.ruleSpec;
     }
 
@@ -517,6 +520,9 @@ function populateTestDataGridFromRules() {
 
 const FAKER_COMMANDS = [];
 const FAKER_COMMANDS_LONGEST_FIRST = [];
+const TOP_LEVEL_TYPE_OPTIONS = ['enum', 'literal', 'regex'];
+const FAKER_SECTION_LABEL = '-- faker --';
+const FAKER_SECTION_VALUE = '__faker_section__';
 
 // TODO: add fakerCommand to the TestDataRule already parsed out
 function findFakerCommand(aString) {
@@ -567,8 +573,68 @@ function identifyFakerCommands() {
   FAKER_COMMANDS.length = 0;
   FAKER_COMMANDS_LONGEST_FIRST.length = 0;
 
-  getKnownFakerCommandsAlphabetical().forEach((command) => FAKER_COMMANDS.push(command));
+  TOP_LEVEL_TYPE_OPTIONS.forEach((typeOption) => FAKER_COMMANDS.push(typeOption));
+  getKnownFakerCommandsAlphabetical()
+    .filter((command) => command !== 'RegEx')
+    .forEach((command) => FAKER_COMMANDS.push(command));
   getKnownFakerCommandsLongestFirst().forEach((command) => FAKER_COMMANDS_LONGEST_FIRST.push(command));
+}
+
+function getTabulatorTypeEditorValues() {
+  const typeValues = TOP_LEVEL_TYPE_OPTIONS.map((typeOption) => ({ value: typeOption, label: typeOption }));
+  const fakerHeader = {
+    value: FAKER_SECTION_VALUE,
+    label: FAKER_SECTION_LABEL,
+    elementAttributes: { disabled: true },
+  };
+  const fakerCommandValues = getKnownFakerCommandsAlphabetical()
+    .filter((command) => command !== 'RegEx')
+    .map((command) => ({ value: command, label: command }));
+  return [...typeValues, fakerHeader, ...fakerCommandValues];
+}
+
+function tabulatorTypeSelectEditor(cell, onRendered, success, cancel) {
+  const editor = document.createElement('select');
+  editor.style.width = '100%';
+  editor.style.boxSizing = 'border-box';
+
+  const values = getTabulatorTypeEditorValues();
+  values.forEach((entry) => {
+    const option = document.createElement('option');
+    option.value = entry.value;
+    option.textContent = entry.label;
+    if (entry.value === FAKER_SECTION_VALUE) {
+      option.disabled = true;
+    }
+    editor.appendChild(option);
+  });
+
+  const currentValue = String(cell.getValue() ?? '').trim();
+  editor.value = currentValue;
+
+  onRendered(() => {
+    editor.focus();
+  });
+
+  editor.addEventListener('change', () => {
+    const selectedValue = String(editor.value ?? '').trim();
+    if (selectedValue === FAKER_SECTION_VALUE) {
+      cancel();
+      return;
+    }
+    success(selectedValue);
+  });
+
+  editor.addEventListener('blur', () => {
+    const selectedValue = String(editor.value ?? '').trim();
+    if (selectedValue === FAKER_SECTION_VALUE) {
+      cancel();
+      return;
+    }
+    success(selectedValue);
+  });
+
+  return editor;
 }
 
 function setupTestDataEditGrid(gridDiv) {
@@ -598,7 +664,7 @@ function setupTestDataEditGrid(gridDiv) {
     if (!defnGridBridge) {
       return;
     }
-    defnGridBridge.addRows([{ columnName: '', type: 'RegEx', value: '', comments: '' }]);
+    defnGridBridge.addRows([{ columnName: '', type: 'regex', value: '', comments: '' }]);
     convertGridToText();
   });
 
@@ -673,14 +739,14 @@ function setupTabulatorDefnEditor(tableDiv) {
   defnGridApi = new Tabulator(tableDiv, {
     data: [],
     columns: [
-      { title: 'columnName', field: 'columnName', editor: 'input' },
+      { title: 'columnName', field: 'columnName', editor: 'input', headerSort: false },
       {
         title: 'type',
         field: 'type',
-        editor: 'list',
-        editorParams: { values: FAKER_COMMANDS },
+        editor: tabulatorTypeSelectEditor,
+        headerSort: false,
       },
-      { title: 'value', field: 'value', editor: 'input' },
+      { title: 'value', field: 'value', editor: 'input', headerSort: false },
     ],
     selectableRows: true,
     movableRows: true,
@@ -688,7 +754,15 @@ function setupTabulatorDefnEditor(tableDiv) {
     cellEditing: (cell) => {
       beginTabulatorDraftTracking(cell);
     },
-    cellEdited: () => {
+    cellEdited: (cell) => {
+      const field = cell?.getField?.() || cell?.getColumn?.()?.getDefinition?.()?.field;
+      if (field === 'type') {
+        const selectedValue = String(cell?.getValue?.() ?? '').trim();
+        if (selectedValue === FAKER_SECTION_VALUE) {
+          const previousValue = cell?.getOldValue?.();
+          cell?.setValue?.(previousValue || '', true);
+        }
+      }
       convertGridToText();
     },
     rowMoved: () => {
@@ -755,6 +829,29 @@ function clearTabulatorDraftTracking() {
   activeDefnCellEdit = null;
 }
 
+function normalizeEnumRuleDefinition(value) {
+  const rawValue = String(value ?? '').trim();
+  if (rawValue.length === 0) {
+    return '';
+  }
+  if (/^enum\s*\(/i.test(rawValue)) {
+    return rawValue;
+  }
+  return `enum(${rawValue})`;
+}
+
+function normalizeLiteralRuleDefinition(value) {
+  const rawValue = String(value ?? '');
+  const trimmedValue = rawValue.trim();
+  if (trimmedValue.length === 0) {
+    return '';
+  }
+  if (/^(literal|datatype\.literal|awd\.datatype\.literal)\s*\(/i.test(trimmedValue)) {
+    return trimmedValue;
+  }
+  return `literal(${rawValue})`;
+}
+
 function convertGridToText() {
   if (!defnGridBridge) {
     return;
@@ -774,16 +871,26 @@ function convertGridToText() {
     outputLines.push(resolvedRowData.columnName || '');
 
     let ruleLine = '';
-    switch (resolvedRowData.type) {
-      case 'RegEx':
+    const resolvedType = String(resolvedRowData.type || '').trim();
+    const lowerType = resolvedType.toLowerCase();
+    switch (lowerType) {
+      case 'regex':
         ruleLine = resolvedRowData.value || '';
         break;
       case 'enum':
+        ruleLine = normalizeEnumRuleDefinition(resolvedRowData.value);
+        break;
+      case 'literal':
+        ruleLine = normalizeLiteralRuleDefinition(resolvedRowData.value);
+        break;
+      case 'faker':
         ruleLine = resolvedRowData.value || '';
         break;
-      // TODO Literal
+      case '__faker_section__':
+        ruleLine = '';
+        break;
       default: {
-        let dataType = resolvedRowData.type || '';
+        let dataType = resolvedType;
         if (dataType.startsWith('faker.')) {
           dataType = dataType.replace('faker.', '');
         }

--- a/packages/core-ui/src/tests/generator/data-generator-page.test.js
+++ b/packages/core-ui/src/tests/generator/data-generator-page.test.js
@@ -198,6 +198,27 @@ describe('DataGeneratorPage', () => {
     expect(spec).toBe('');
   });
 
+  test('schema source type dropdown uses enum, literal, regex, faker order', () => {
+    const page = new DataGeneratorPage({
+      parentElement: document.getElementById('app'),
+      documentObj: document,
+      alertFn,
+      faker: { word: { noun: () => 'x' } },
+      RandExp: function RandExp() {},
+      TabulatorCtor: FakeTabulator,
+      GridExtensionClass: FakeGridExtension,
+      ExporterClass: FakeExporter,
+      DownloadClass: FakeDownload,
+      TestDataGeneratorClass: FakeTestDataGenerator,
+    });
+    page.init();
+
+    const sourceTypeSelect = document.querySelector('[data-field="sourceType"]');
+    const optionValues = Array.from(sourceTypeSelect.querySelectorAll('option')).map((option) => option.value);
+
+    expect(optionValues).toEqual(['enum', 'literal', 'regex', 'faker']);
+  });
+
   test('schemaRowsToSpecWithTokens preserves comments and blank lines', () => {
     const spec = schemaRowsToSpecWithTokens(
       [

--- a/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
+++ b/packages/core-ui/src/tests/grid/test-data-defn-engine-compat.test.js
@@ -433,6 +433,58 @@ describe('test data definition editor engine compatibility', () => {
     expect(rebuilt).toContain('# second comment');
   });
 
+  test('enum type rows are emitted as enum(...) definitions in schema text', async () => {
+    const TabulatorMock = installTabulatorMock();
+
+    enableTestDataGenerationInterface(
+      'host',
+      {
+        setGridFromGenericDataTable: jest.fn(),
+      },
+      {
+        renderTextFromGrid: jest.fn(),
+      },
+      {
+        getRowCount: jest.fn(() => 0),
+        getSelectedRowIndexes: jest.fn(() => []),
+      }
+    );
+
+    TabulatorMock.latestInstance.rows = [{ columnName: 'Priority', type: 'enum', value: '1,2,3,4' }];
+    TabulatorMock.latestInstance.options.cellEdited();
+    await flushUi();
+
+    expect(document.getElementById('testdatadefntext').value).toContain('Priority\nenum(1,2,3,4)');
+
+    delete global.Tabulator;
+  });
+
+  test('literal type rows are emitted as literal(...) definitions in schema text', async () => {
+    const TabulatorMock = installTabulatorMock();
+
+    enableTestDataGenerationInterface(
+      'host',
+      {
+        setGridFromGenericDataTable: jest.fn(),
+      },
+      {
+        renderTextFromGrid: jest.fn(),
+      },
+      {
+        getRowCount: jest.fn(() => 0),
+        getSelectedRowIndexes: jest.fn(() => []),
+      }
+    );
+
+    TabulatorMock.latestInstance.rows = [{ columnName: 'Separator', type: 'literal', value: '.' }];
+    TabulatorMock.latestInstance.options.cellEdited();
+    await flushUi();
+
+    expect(document.getElementById('testdatadefntext').value).toContain('Separator\nliteral(.)');
+
+    delete global.Tabulator;
+  });
+
   test('load sample schema button populates text schema with literal, enum, regex, and faker examples', () => {
     installTabulatorMock();
 

--- a/packages/core-ui/src/tests/grid/testdatadefn-faker-dropdown-literals.test.js
+++ b/packages/core-ui/src/tests/grid/testdatadefn-faker-dropdown-literals.test.js
@@ -35,7 +35,9 @@ describe('Faker Dropdown Literal Commands', () => {
     it('should populate FAKER_COMMANDS array', () => {
       const commands = getFakerCommands();
       expect(commands.length).toBeGreaterThan(0);
-      expect(commands).toContain('RegEx');
+      expect(commands.slice(0, 3)).toEqual(['enum', 'literal', 'regex']);
+      expect(commands).not.toContain('FAKER');
+      expect(commands).not.toContain('-------');
     });
 
     it('should include primitive-returning commands', () => {

--- a/packages/core/js/data_generation/testDataRulesCompiler.js
+++ b/packages/core/js/data_generation/testDataRulesCompiler.js
@@ -44,6 +44,15 @@ export class TestDataRulesCompiler {
         // unassigned a type, try and generate one
         this.compilationReportLines.push(`Identifying type for ${rule.name}`);
 
+        // Check for explicit literal patterns first
+        if (this.isLiteralPattern(rule.ruleSpec)) {
+          const literalValue = this.extractLiteralValue(rule.ruleSpec);
+          this.compilationReportLines.push(`${rule.name} is a valid 'literal': ${rule.ruleSpec}`);
+          rule.ruleSpec = literalValue;
+          rule.type = 'literal';
+          return;
+        }
+
         // Check for enum patterns first
         if (this.isEnumPattern(rule.ruleSpec)) {
           enumValidator.validate(rule);
@@ -157,6 +166,20 @@ export class TestDataRulesCompiler {
     }
 
     return false;
+  }
+
+  isLiteralPattern(ruleSpec) {
+    const spec = String(ruleSpec || '').trim();
+    return /^(literal|datatype\.literal|awd\.datatype\.literal)\s*\(/i.test(spec);
+  }
+
+  extractLiteralValue(ruleSpec) {
+    const spec = String(ruleSpec || '').trim();
+    const match = spec.match(/^(?:literal|datatype\.literal|awd\.datatype\.literal)\s*\(([\s\S]*)\)\s*$/i);
+    if (!match) {
+      return spec;
+    }
+    return match[1];
   }
 
   isValid() {

--- a/packages/core/src/tests/data_generation/enum-compiler-integration.test.js
+++ b/packages/core/src/tests/data_generation/enum-compiler-integration.test.js
@@ -104,4 +104,19 @@ describe('TestDataRulesCompiler with Enum Support', () => {
       expect(rules[4].type).toBe('enum');
     });
   });
+
+  describe('literal pattern detection', () => {
+    test('detects explicit literal formats', () => {
+      expect(compiler.isLiteralPattern('literal(.)')).toBe(true);
+      expect(compiler.isLiteralPattern('datatype.literal(1,2,3)')).toBe(true);
+      expect(compiler.isLiteralPattern('awd.datatype.literal(value)')).toBe(true);
+    });
+
+    test('explicit literal compiles to literal type and unwraps value', () => {
+      const rules = [new TestDataRule('DotLiteral', 'literal(.)')];
+      compiler.compile(rules);
+      expect(rules[0].type).toBe('literal');
+      expect(rules[0].ruleSpec).toBe('.');
+    });
+  });
 });


### PR DESCRIPTION
closes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit literal value definitions in data generation schemas.

* **Accessibility**
  * Improved initial loading message with ARIA live-region attributes for better screen reader support.

* **Bug Fixes**
  * Reordered and normalized schema source type options in the UI and standardized type naming/casing.

* **Tests**
  * Added and updated tests covering literal pattern detection, dropdown ordering, and related editor behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eviltester/grid-table-editor/pull/99)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->