### PR TITLE
configurable row count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ When changing frontend UI code, Storybook stories, UI test abstractions, or brow
 
 - read `docs/frontend-component-migration-plan.md` before making changes
 - read `docs/frontend-component-architecture.md` for the current page/component/service layering model
+- read `docs/frontend-legacy-ui-elimination-plan.md` when changing or discovering UI code that still uses legacy controls, broad imperative helpers, document-scoped lookup, or compatibility facades
 - prefer the `Controller + View + createComponent` pattern for new or migrated UI components
 - keep components mounted into one explicit root element
 - avoid global `document.querySelector`/`getElementById` inside reusable components; query within the component root instead

--- a/apps/web/src/stories/export-format-interactions.js
+++ b/apps/web/src/stories/export-format-interactions.js
@@ -48,7 +48,7 @@ async function playSetTextFromGrid({ canvasElement }) {
 
 async function playCsvRoundTrip({ canvasElement }) {
   const canvas = within(canvasElement);
-  await clickByText(canvas, 'Preview (10)');
+  await clickByText(canvas, 'Preview');
   await waitFor(() => expect(canvas.getByText('Edit')).toBeTruthy());
 
   const textArea = await setTextareaValue(canvasElement, 'Name,Role\nAda,Engineer\nBob,Tester');
@@ -70,12 +70,12 @@ async function playJsonOptionsPreview({ canvasElement }) {
 
 async function playPreviewEditMode({ canvasElement }) {
   const canvas = within(canvasElement);
-  const modeButton = canvas.getByText('Preview (10)');
+  const modeButton = canvas.getByText('Preview');
   await userEvent.click(modeButton);
   await waitFor(() => expect(canvas.getByText('Edit')).toBeTruthy());
 
   await userEvent.click(canvas.getByText('Edit'));
-  await waitFor(() => expect(canvas.getByText('Preview (10)')).toBeTruthy());
+  await waitFor(() => expect(canvas.getByText('Preview')).toBeTruthy());
 }
 
 async function playDelimitedOptionsPreview({ canvasElement }) {
@@ -103,7 +103,8 @@ async function playPreviewAlreadyRendered({ canvasElement }) {
     expect(textArea?.value?.length || 0).toBeGreaterThan(0);
   });
 
-  await expect(canvas.getByRole('button', { name: 'Preview (10)' })).toBeTruthy();
+  await expect(canvas.getByRole('button', { name: 'Preview' })).toBeTruthy();
+  await expect(canvas.getByRole('spinbutton', { name: 'Preview row count' })).toHaveValue(10);
   await userEvent.click(canvas.getByRole('button', { name: 'Copy' }));
   await waitFor(() => {
     expect(textArea?.value?.length || 0).toBeGreaterThan(0);

--- a/apps/web/src/stories/export-format-interactions.js
+++ b/apps/web/src/stories/export-format-interactions.js
@@ -1,7 +1,7 @@
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 async function clickByText(canvas, text) {
-  const button = canvas.getByText(text);
+  const button = canvas.getByRole('button', { name: text });
   await userEvent.click(button);
   return button;
 }
@@ -70,12 +70,12 @@ async function playJsonOptionsPreview({ canvasElement }) {
 
 async function playPreviewEditMode({ canvasElement }) {
   const canvas = within(canvasElement);
-  const modeButton = canvas.getByText('Preview');
+  const modeButton = canvas.getByRole('button', { name: 'Preview' });
   await userEvent.click(modeButton);
-  await waitFor(() => expect(canvas.getByText('Edit')).toBeTruthy());
+  await waitFor(() => expect(canvas.getByRole('button', { name: 'Edit' })).toBeTruthy());
 
-  await userEvent.click(canvas.getByText('Edit'));
-  await waitFor(() => expect(canvas.getByText('Preview')).toBeTruthy());
+  await userEvent.click(canvas.getByRole('button', { name: 'Edit' }));
+  await waitFor(() => expect(canvas.getByRole('button', { name: 'Preview' })).toBeTruthy());
 }
 
 async function playDelimitedOptionsPreview({ canvasElement }) {

--- a/apps/web/src/stories/export-preview-story-harness.js
+++ b/apps/web/src/stories/export-preview-story-harness.js
@@ -265,11 +265,12 @@ function setCheckboxValue(input, checked) {
 }
 
 function setPreviewRowLimit(surface, value) {
-  const previewButton = surface.querySelector('#previewEditModeButton');
-  if (!previewButton) {
+  const previewRowsInput = surface.querySelector('#previewRowsCount');
+  if (!previewRowsInput) {
     return;
   }
-  previewButton.textContent = `Preview (${value})`;
+  previewRowsInput.value = String(value);
+  previewRowsInput.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
 function getActiveExportSelection(surface) {
@@ -454,6 +455,9 @@ function renderGridPreviewStory({
   const workspace = createImportExportWorkspaceComponent({
     root: workspaceHost,
     documentObj: document,
+    props: {
+      previewRowLimit,
+    },
     services: {
       importExportControls: legacyControls,
     },
@@ -509,7 +513,6 @@ function renderGridPreviewStory({
     return result;
   };
 
-  importExportController.previewRowLimit = previewRowLimit;
   setPreviewRowLimit(surface, previewRowLimit);
   withScopedDocument(surface, () => {
     selectExportFormat(surface, format);

--- a/apps/web/src/stories/import-export-workspace.stories.js
+++ b/apps/web/src/stories/import-export-workspace.stories.js
@@ -97,7 +97,7 @@ const meta = {
       options: ['csv', 'json', 'markdown'],
     },
     previewRowLimit: {
-      control: { type: 'number', min: 0, max: 50, step: 1 },
+      control: { type: 'number', min: 1, max: 50, step: 1 },
     },
   },
   render: renderImportExportWorkspaceStory,

--- a/apps/web/src/stories/import-export-workspace.stories.js
+++ b/apps/web/src/stories/import-export-workspace.stories.js
@@ -53,6 +53,9 @@ function renderImportExportWorkspaceStory(args) {
   const component = createImportExportWorkspaceComponent({
     root,
     documentObj: document,
+    props: {
+      previewRowLimit: args.previewRowLimit,
+    },
   });
 
   component.setExporter(exporter);
@@ -86,11 +89,15 @@ const meta = {
   },
   args: {
     format: 'csv',
+    previewRowLimit: 10,
   },
   argTypes: {
     format: {
       control: 'select',
       options: ['csv', 'json', 'markdown'],
+    },
+    previewRowLimit: {
+      control: { type: 'number', min: 0, max: 50, step: 1 },
     },
   },
   render: renderImportExportWorkspaceStory,
@@ -103,12 +110,13 @@ export const Default = {
     docs: {
       description: {
         story:
-          'Shows the composed app-side import/export workspace mounted through the new Phase 6 feature boundary. Click Set Text From Grid to refresh preview text, switch formats, and use the options panel inside the same mounted component tree.',
+          'Shows the composed app-side import/export workspace mounted through the new Phase 6 feature boundary. Use the compact preview row-count input next to Preview to change the sample size, click Set Text From Grid to refresh preview text, and switch formats inside the same mounted component tree.',
       },
     },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    await expect(canvas.getByRole('spinbutton', { name: 'Preview row count' })).toHaveValue(10);
     await userEvent.click(canvas.getByRole('button', { name: 'v Set Text From Grid v' }));
     await waitFor(() => {
       expect(canvasElement.querySelector('#markdownarea')?.value?.length || 0).toBeGreaterThan(0);
@@ -128,7 +136,7 @@ export const JsonPreview = {
     docs: {
       description: {
         story:
-          'Shows the same workspace after switching to JSON so the shared format selector, preview editor, and options panel can be reviewed together in a non-CSV state.',
+          'Shows the same workspace after switching to JSON so the shared format selector, preview editor, row-count control, and options panel can be reviewed together in a non-CSV state.',
       },
     },
   },

--- a/apps/web/src/stories/text-preview-editor.stories.js
+++ b/apps/web/src/stories/text-preview-editor.stories.js
@@ -43,7 +43,7 @@ export const PreviewMode = {
     docs: {
       description: {
         story:
-          'Preview-mode state with Auto Preview enabled and the preview-row count reflected in the toggle button label.',
+          'Shows Preview mode with Auto Preview enabled and the dedicated preview row-count spinbutton set to 10. Reviewers should hover the help button, confirm the tooltip mentions the first 10 rows, and try changing the Preview row count to see how the preview-specific guidance follows that value while the toggle button remains labeled Preview.',
       },
     },
   },

--- a/apps/web/src/stories/text-preview-editor.stories.js
+++ b/apps/web/src/stories/text-preview-editor.stories.js
@@ -59,7 +59,8 @@ export const PreviewMode = {
     });
 
     await expect(autoPreviewCheckbox).toBeEnabled();
-    await expect(canvas.getByRole('button', { name: 'Preview (10)' })).toBeTruthy();
+    await expect(canvas.getByRole('button', { name: 'Preview' })).toBeTruthy();
+    await expect(canvas.getByRole('spinbutton', { name: 'Preview row count' })).toHaveValue(10);
   },
 };
 

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -950,6 +950,10 @@ body.theme-dark .generator-status-text[data-severity='info'] {
   width: 6rem;
 }
 
+.app-preview-row-count-control #previewRowsCount {
+  width: 3.25rem;
+}
+
 #generator-preview-grid {
   width: 100%;
   height: 420px;

--- a/docs/frontend-legacy-ui-elimination-plan.md
+++ b/docs/frontend-legacy-ui-elimination-plan.md
@@ -1,0 +1,260 @@
+# Frontend Legacy UI Elimination Plan
+
+This plan tracks the remaining work needed to remove old UI control patterns from the frontend after the first component migration. The goal is a UI architecture that is framework-light today, but cleanly movable to React, Web Components, Lit, or another renderer later.
+
+The earlier migration created many component boundaries. This plan is stricter: a feature is not complete while it still depends on an old control class, generator-specific DOM helper, document-scanning UI helper, or broad imperative coordinator for its core user behavior.
+
+Use this document with:
+
+- `docs/frontend-component-architecture.md`
+- `docs/frontend-component-migration-plan.md`
+- `AGENTS.md`
+
+## Target Standard
+
+The target frontend structure is still `Controller + View + createComponent`, but the standard for this cleanup is higher than the first migration pass.
+
+- UI features expose a `createThingComponent(...)` factory with `update(...)`, `destroy()`, and `getState()` where state exists.
+- Controllers own state transitions, validation, parsing, and orchestration. They are testable without a DOM.
+- Views own rendering and root-scoped event binding. They query only inside their supplied root.
+- Components receive services, adapters, callbacks, `documentObj`, and `windowObj` explicitly.
+- Components communicate through callbacks, component APIs, or explicit services rather than by mutating sibling DOM.
+- Browser APIs are isolated behind services or adapters: files, drag/drop, clipboard, downloads, dialogs, timers, tooltips, and third-party widgets.
+- Fixed IDs exist only for page mount roots, documented host contracts, or compatibility windows with a removal plan.
+- Storybook stories use real visible child behavior, small harnesses, and reviewer-facing descriptions.
+- Tests query user-facing roles/names first, then root-scoped `data-*` hooks where roles are not practical.
+- A migrated feature must have focused controller tests, DOM/component tests for rendered behavior, Storybook coverage, and page/browser coverage when the whole page workflow is affected.
+
+## Anti-Patterns To Remove
+
+These are the patterns this plan treats as legacy, even when they are hidden beneath componentized shells.
+
+- Broad classes named `*Controls` that own rendering, DOM lookup, event binding, workflow state, and service calls in one object.
+- `addHTMLtoGui(...)`, `addToGui(...)`, `addHooksToPage(...)`, or `bindExistingGui(...)` as the primary UI lifecycle.
+- Component internals using `document.querySelector(...)` or `document.getElementById(...)` for reusable UI state.
+- Reusable components depending on generator- or app-specific DOM helper modules for their core rendering.
+- Storybook harnesses that monkey-patch `document.querySelector(...)` or `document.getElementById(...)` to make old code appear scoped.
+- Individual option panels that render with `parent.innerHTML` and expose only ad hoc callbacks.
+- Compatibility wrappers that remain because runtime code still consumes old public shapes rather than component APIs.
+
+## Current Legacy Inventory
+
+This inventory is the starting point. Update it as each phase discovers more work.
+
+### Active Production Blockers
+
+- `packages/core-ui/js/gui_components/app/import-export-controls.js`
+  - `ImportExportControls` still coordinates preview/edit mode, import/export behavior, progress messages, format visibility, options layout, and preview row limiting underneath `ImportExportWorkspace`.
+- `packages/core-ui/js/gui_components/app/exportControls.js`
+  - `ExportControls` still binds download/copy behavior to fixed DOM selectors and updates status elements directly.
+- `packages/core-ui/js/gui_components/options_panels/*`
+  - Individual format option panels still use old `addToGui()` classes, direct root mutation, and ad hoc callback APIs, even though `FormatOptionsPanel` is component-shaped around them.
+- `packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js`
+  - The shared schema component still imports generator-specific row render and event helpers.
+- `packages/core-ui/js/gui_components/generator/schema/data-generator-schema-ui.js`
+  - Generator-named DOM helpers still render shared schema rows and handle row interactions.
+- `packages/core-ui/js/gui_components/generator/runtime/data-generator-page-runtime.js`
+  - `DataGeneratorPage` still acts as a large page coordinator with many behavior methods that should be pushed into page/feature controllers or services.
+
+### Compatibility And Cleanup Candidates
+
+- `packages/core-ui/js/gui_components/app/tabbed-text-control.js`
+  - Old import/export tabs control. It appears test-only after the `TextPreviewEditor` and `FormatSelector` migration and should be removed if no runtime/story consumer remains.
+- `packages/core-ui/js/gui_components/data-grid-editor/main-display-grid.js`
+  - Grid engine selector facade. Keep only while multiple grid engines remain an intentional runtime feature.
+- `packages/core-ui/js/gui_components/data-grid-editor/tabulator/main-display-grid.js`
+  - Compatibility facade around `createDataGridComponent(...)`. Remove once app runtime accepts the component API directly.
+- `packages/core-ui/js/gui_components/data-grid-editor/ag-grid/*`
+  - Legacy AG Grid path. Either migrate behind the same component standards or remove if AG Grid is no longer supported.
+- `packages/core-ui/js/gui_components/data-grid-editor/gridControl.js`
+  - Old grid toolbar and grid shell control still used by the AG Grid path; only `shouldEnforceUniqueColumnNames(...)` is used by the active Tabulator component path.
+- `packages/core-ui/js/gui_components/app/drag-drop-control.js`
+  - Imperative drag/drop helper. It can remain as an adapter only if it has a narrow service contract and no feature orchestration responsibilities.
+- `packages/core-ui/js/gui_components/shared/modal-confirm.js` and `packages/core-ui/js/gui_components/shared/modal-text-input.js`
+  - Imperative modal helpers currently wrapped by services. They should become component-backed services or be explicitly documented as service internals.
+- `packages/core-ui/js/help/help-tooltips.js`
+  - Global tooltip scanning service. It should become a scoped tooltip service or component API that does not require document-wide rescans for reusable components.
+- `packages/core-ui/js/gui_components/shared/theme-toggle.js`
+  - Imperative page helper. It should become a small component or page-shell feature.
+
+## Phase 0: Baseline Audit And Tracking
+
+Goal: make the remaining legacy surface explicit and measurable before refactoring.
+
+- [x] Add this plan to the standard frontend reading list in `AGENTS.md` or the relevant contributor docs.
+- [ ] Add a short note to `docs/frontend-component-migration-plan.md` explaining that this plan supersedes the previous "complete" status for stricter legacy elimination.
+- [ ] Build a search checklist for legacy markers: `addToGui`, `addHTMLtoGui`, `addHooksToPage`, `bindExistingGui`, `document.querySelector`, `document.getElementById`, `parent.innerHTML`, `rootElement`, `legacy`, and old `*Controls` classes.
+- [ ] Classify each match as active production, active adapter, compatibility facade, Storybook-only, test-only, or dead code.
+- [ ] Add regression coverage before deleting or replacing any legacy path that still has production behavior.
+
+Exit criteria:
+
+- Every known legacy item is assigned to a phase below or explicitly documented as an accepted adapter.
+- There is no "probably migrated" area without an owner or follow-up.
+
+## Phase 1: Import/Export Workspace Behavior
+
+Goal: remove `ImportExportControls` and `ExportControls` as behavior coordinators underneath the componentized workspace.
+
+- [ ] Define the final `ImportExportWorkspace` state model: selected format, preview/edit mode, preview row limit, auto-preview state, import busy state, export busy state, progress/status messages, text dirty state, active options, and supported import/export affordances.
+- [ ] Move preview/edit mode state and text dirty tracking into `ImportExportWorkspaceController` or a focused `TextPreviewEditorController` API.
+- [ ] Move preview rendering from grid/data table into an import/export preview service that receives exporter/importer dependencies explicitly.
+- [ ] Move text import and file import orchestration into services that return state transitions instead of mutating DOM.
+- [ ] Replace `ExportControls` with download/copy services plus component-owned busy/status rendering.
+- [ ] Replace `legacyControls.bindExistingGui(...)` with child components and injected services.
+- [ ] Remove `getImportExportControls()` from the public component API or replace it with intentional service-level accessors.
+- [ ] Update `ImportExportWorkspace` Storybook stories to use the real new behavior without injecting `ImportExportControls`.
+- [ ] Update export-format Storybook harnesses so they no longer instantiate `ImportExportControls` or patch document lookup.
+- [ ] Delete `import-export-controls.js` and `exportControls.js` after runtime, tests, and stories no longer import them.
+
+Required coverage:
+
+- Controller tests for preview row limits, mode transitions, dirty state, busy state, and status transitions.
+- DOM/component tests for preview/edit mode, row count changes, import button state, copy/download controls, status rendering, and format changes.
+- Browser tests for app import/export workflows, file import preview, full import, download, copy, and format-specific rendering.
+- Storybook coverage for preview, edit, busy import, busy export, unsupported format, and error states.
+
+## Phase 2: Format Option Panels
+
+Goal: replace the old individual option panel classes with component-compatible format option definitions.
+
+- [ ] Define a standard format option panel contract with `render`, `read`, `write`, `validate`, `setDirty`, `destroy`, and `onApply` behavior.
+- [ ] Convert CSV and DSV first as proving slices because they exercise delimiter presets and custom values.
+- [ ] Convert JSON and JSONL next because they share structure but have mode differences.
+- [ ] Convert XML, SQL, Markdown, HTML, Gherkin, and ASCII panels.
+- [ ] Convert code-language panels: C#, Java, JavaScript, Kotlin, Perl, PHP, Python, Ruby, and TypeScript.
+- [ ] Convert unit-test framework panels.
+- [ ] Remove `HtmlDataValues` selector helper once panels read/write through controllers or scoped view helpers.
+- [ ] Replace `panel.addToGui()` usage in `FormatOptionsPanelView` with component or panel-definition mounting.
+- [ ] Keep option sanitization in services, not in view code.
+- [ ] Delete or retire old files under `packages/core-ui/js/gui_components/options_panels/` once converted.
+
+Required coverage:
+
+- Controller tests for each materially different option family.
+- DOM/component tests for validation, dirty/apply behavior, set-from-options behavior, and custom delimiter handling.
+- Storybook stories for each format family with descriptions that explain defaults, limits, and expected applied payloads.
+- Existing export-format browser coverage remains green.
+
+## Phase 3: Shared Schema Definition Internals
+
+Goal: make `SharedSchemaDefinition` genuinely shared, instead of a shared wrapper around generator-named DOM helpers.
+
+- [ ] Move schema row rendering out of `generator/schema/data-generator-schema-ui.js` into `SharedSchemaDefinitionView` or a dedicated shared schema rows view.
+- [ ] Move row input, button, command picker, drag/drop, and tooltip behavior behind shared controller/view methods.
+- [ ] Remove generator-specific IDs from shared internals except where passed as documented host contract props.
+- [ ] Replace `generator-schema-*` class names in shared internals with shared names, keeping compatibility classes only where styles or tests require a temporary bridge.
+- [ ] Make `buildSchemaModeHelpHtml(...)` either a shared service input or page-specific callback, not a reason for shared internals to import generator modules.
+- [ ] Delete unused exports from `generator/schema/data-generator-schema-ui.js`.
+- [ ] Delete `data-generator-schema-ui.js` entirely if no generator-specific behavior remains.
+
+Required coverage:
+
+- Shared schema controller tests for text/schema mode, parsing, semantic validation, command selection, row operations, and drag/drop instructions.
+- DOM/component tests for rendered rows, row editing, command picker opening, row add/remove/move, text sync, sample insert, and help text.
+- Storybook stories for app and generator schema variants using the same shared internals.
+- Browser tests for app schema generation and generator schema generation stay green.
+
+## Phase 4: Generator Runtime Slimming
+
+Goal: reduce `DataGeneratorPage` to page runtime composition and move feature behavior into feature controllers/services.
+
+- [ ] Split generator generation orchestration into a feature controller or service that does not query page DOM for row counts or output text.
+- [ ] Make `GeneratorControls` the source of selected format, row counts, pairwise visibility, and generation busy/status state.
+- [ ] Make `GeneratorPreview` the source of preview text and preview grid state.
+- [ ] Move pairwise visibility calculation behind the schema/generation service boundary and update controls through props.
+- [ ] Remove fallback DOM reads from `DataGeneratorPage.getSelectedOutputType()`, `parseRowCount(...)`, and `applyCurrentTypeOptions(...)`.
+- [ ] Keep `DataGeneratorPage` responsible only for dependency construction, top-level composition, and lifecycle.
+
+Required coverage:
+
+- Unit tests for generation orchestration without DOM.
+- Component tests for generator controls and preview state.
+- Generator page Storybook stories using the new public component APIs.
+- Browser tests for preview, generate file, pairwise generate, options apply, and schema mode switching.
+
+## Phase 5: Grid Compatibility Decision
+
+Goal: remove or migrate grid paths that keep old controls alive.
+
+- [ ] Decide whether AG Grid remains a supported runtime engine.
+- [ ] If AG Grid is not supported, remove `data-grid-editor/ag-grid/*`, AG Grid tests, and the grid engine selector path.
+- [ ] If AG Grid remains supported, wrap it behind the same `DataGridComponent` contract as Tabulator.
+- [ ] Remove `GridControl` after AG Grid no longer uses it.
+- [ ] Replace `shouldEnforceUniqueColumnNames(documentObj)` with component state or an injected option from `GridToolbar`.
+- [ ] Update architecture docs to describe the final grid support policy.
+
+Required coverage:
+
+- Grid component controller/view tests for unique column-name behavior.
+- Browser tests for the supported grid engine path.
+- If multiple grid engines remain, tests that prove both use the same component-facing contract.
+
+## Phase 6: Shared Services And Page Helpers
+
+Goal: narrow remaining imperative helpers so they are either component-backed services or accepted low-level adapters.
+
+- [ ] Convert confirm and text-input modals into component-backed services with explicit lifecycle and root ownership.
+- [ ] Convert help tooltips into a scoped service or component API that does not require document-wide scans from feature components.
+- [ ] Convert theme toggle into a shared component or page-shell feature.
+- [ ] Keep download, file read, clipboard, drag/drop, timers, and Tabulator wrappers as adapters only if they do not own feature state or rendering.
+- [ ] Document every accepted adapter in `docs/frontend-component-architecture.md`.
+- [ ] Remove service internals that still depend on global document state when an injected document/root is available.
+
+Required coverage:
+
+- Service tests for modal lifecycle, tooltip scoping, theme persistence, drag/drop cleanup, and download/copy behavior.
+- Storybook stories for component-backed modal, tooltip, and theme surfaces where visible.
+- Browser smoke coverage for modal and tooltip behavior in real pages.
+
+## Phase 7: Dead Code, Stories, And Public API Cleanup
+
+Goal: remove old files and old public shapes that only remain because tests or stories still reference them.
+
+- [ ] Delete `TabbedTextControl` after replacing or removing its tests.
+- [ ] Remove Storybook harness monkey patches for document lookup.
+- [ ] Remove test-only imports of old option panels once format option components replace them.
+- [ ] Remove legacy aliases from public barrels unless there is a documented downstream compatibility requirement.
+- [ ] Update Playwright page objects to use current role/name/component APIs after markup changes.
+- [ ] Update `docs/frontend-component-architecture.md` so compatibility examples are current and rare.
+
+Required coverage:
+
+- Full Jest suite for deleted or replaced utilities.
+- Storybook interaction tests for all updated stories.
+- Browser tests for user-facing workflows touched by cleanup.
+
+## Phase 8: Comprehensive Final Review
+
+Goal: prove there is no remaining legacy UI approach that blocks future React or Web Component migration.
+
+- [ ] Re-run the legacy marker audit from Phase 0 and classify every match.
+- [ ] Search for old lifecycle names: `addToGui`, `addHTMLtoGui`, `addHooksToPage`, `bindExistingGui`, `useThisGridFunctionality`, and broad `*Controls` classes.
+- [ ] Search for reusable component global DOM access: `document.querySelector`, `document.getElementById`, `documentObj.querySelector`, and `documentObj.getElementById`.
+- [ ] Search for Storybook document monkey-patching and large harnesses.
+- [ ] Confirm every feature component has controller, view, factory, lifecycle cleanup, Storybook docs, controller tests, and DOM/component tests.
+- [ ] Confirm every accepted adapter is documented, narrow, injected, and free of feature orchestration.
+- [ ] Confirm fixed IDs are only page-level contracts or documented temporary compatibility contracts.
+- [ ] Review `docs/frontend-component-architecture.md` and remove stale compatibility exceptions.
+- [ ] Review `docs/frontend-component-migration-plan.md` and mark the older migration as superseded by this cleanup where appropriate.
+- [ ] Run `pnpm run verify:ui`.
+- [ ] Run `pnpm run verify:local`.
+- [ ] Run broader browser and Storybook gates when the final review includes UI or browser behavior changes: `pnpm run test:browser`, `pnpm run test:storybook`, and `pnpm run build-storybook`.
+
+Exit criteria:
+
+- No active production UI feature depends on a legacy control class or generator/app-specific DOM helper for reusable behavior.
+- No reusable component performs global document lookup for its own internal UI.
+- No Storybook story needs document monkey-patching to make a component appear scoped.
+- Compatibility facades are removed or documented with explicit owners and removal criteria.
+- The architecture docs describe the actual implementation rather than an aspirational state.
+- The final verification gates pass.
+
+## Working Rules
+
+- Keep each phase small enough to review and verify independently.
+- Prefer deleting legacy files after replacement rather than leaving compatibility shadows.
+- Do not move behavior into React/Web Components yet; this plan prepares the architecture without changing framework.
+- Update this document whenever new legacy work is discovered.
+- Add unchecked follow-up items immediately when a phase reveals more work.
+- Treat a feature as incomplete if the componentized shell still delegates core behavior to a legacy control.

--- a/packages/core-ui/js/gui_components/app/import-export-controls.js
+++ b/packages/core-ui/js/gui_components/app/import-export-controls.js
@@ -519,6 +519,13 @@ class ImportExportControls {
     return this.previewRowLimit;
   }
 
+  setPreviewRowLimit(previewRowLimit) {
+    const parsed = Number.parseInt(previewRowLimit, 10);
+    const normalized = Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), 50) : 10;
+    this.previewRowLimit = normalized;
+    return this.previewRowLimit;
+  }
+
   async toggleTextEditMode() {
     if (this.isPreviewTextMode()) {
       this.textEditMode = 'edit';

--- a/packages/core-ui/js/gui_components/app/import-export-workspace/import-export-workspace-view.js
+++ b/packages/core-ui/js/gui_components/app/import-export-workspace/import-export-workspace-view.js
@@ -47,6 +47,7 @@ class ImportExportWorkspaceView {
       callbacks: {
         onToggleMode: this.services.onToggleMode,
         onAutoPreviewChange: this.services.onAutoPreviewChange,
+        onPreviewRowLimitChange: this.services.onPreviewRowLimitChange,
       },
     });
 

--- a/packages/core-ui/js/gui_components/app/import-export-workspace/index.js
+++ b/packages/core-ui/js/gui_components/app/import-export-workspace/index.js
@@ -35,12 +35,18 @@ function createImportExportWorkspaceComponent({ root, props = {}, services = {},
       onAutoPreviewChange: (enabled) => {
         controller.updateProps({ autoPreviewEnabled: enabled });
       },
+      onPreviewRowLimitChange: (previewRowLimit) => {
+        controller.updateProps({ previewRowLimit });
+        legacyControls.setPreviewRowLimit?.(previewRowLimit);
+        view.render();
+      },
     },
   });
 
   view.mount();
   legacyControls.rootElement = view.root;
   legacyControls.bindExistingGui?.(view.root);
+  legacyControls.setPreviewRowLimit?.(controller.getState().previewRowLimit);
   legacyControls._syncGridFromTextButtonState?.();
 
   return {

--- a/packages/core-ui/js/gui_components/app/import-export-workspace/index.js
+++ b/packages/core-ui/js/gui_components/app/import-export-workspace/index.js
@@ -11,6 +11,13 @@ function createImportExportWorkspaceComponent({ root, props = {}, services = {},
   const controller = new ImportExportWorkspaceController({ props });
   const legacyControls =
     services.importExportControls || new ImportExportControls({ documentObj: resolvedDocumentObj });
+
+  const syncPreviewRowLimit = (previewRowLimit) => {
+    const normalizedPreviewRowLimit = legacyControls.setPreviewRowLimit?.(previewRowLimit) ?? previewRowLimit;
+    controller.updateProps({ previewRowLimit: normalizedPreviewRowLimit });
+    return normalizedPreviewRowLimit;
+  };
+
   const view = new ImportExportWorkspaceView({
     root,
     controller,
@@ -36,8 +43,7 @@ function createImportExportWorkspaceComponent({ root, props = {}, services = {},
         controller.updateProps({ autoPreviewEnabled: enabled });
       },
       onPreviewRowLimitChange: (previewRowLimit) => {
-        controller.updateProps({ previewRowLimit });
-        legacyControls.setPreviewRowLimit?.(previewRowLimit);
+        syncPreviewRowLimit(previewRowLimit);
         view.render();
       },
     },
@@ -46,12 +52,15 @@ function createImportExportWorkspaceComponent({ root, props = {}, services = {},
   view.mount();
   legacyControls.rootElement = view.root;
   legacyControls.bindExistingGui?.(view.root);
-  legacyControls.setPreviewRowLimit?.(controller.getState().previewRowLimit);
+  syncPreviewRowLimit(controller.getState().previewRowLimit);
   legacyControls._syncGridFromTextButtonState?.();
 
   return {
     update(nextProps) {
       controller.updateProps(nextProps);
+      if (Object.prototype.hasOwnProperty.call(nextProps, 'previewRowLimit')) {
+        syncPreviewRowLimit(controller.getState().previewRowLimit);
+      }
       view.render();
     },
     destroy() {

--- a/packages/core-ui/js/gui_components/app/text-preview-editor/index.js
+++ b/packages/core-ui/js/gui_components/app/text-preview-editor/index.js
@@ -1,9 +1,10 @@
 import { createUpdateHelpHints } from '../../../help/help-tooltips.js';
 import { resolveDocumentObj } from '../../shared/dom/default-objects.js';
+import { createRowCountControl } from '../../shared/row-count-control/index.js';
 import { TextPreviewEditorController } from './text-preview-editor-controller.js';
 import { TextPreviewEditorView } from './text-preview-editor-view.js';
 
-function createTextPreviewEditorComponent({ root, props = {}, callbacks = {}, documentObj } = {}) {
+function createTextPreviewEditorComponent({ root, props = {}, callbacks = {}, services = {}, documentObj } = {}) {
   const resolvedDocumentObj = resolveDocumentObj(documentObj, root);
   const controller = new TextPreviewEditorController({ props, callbacks });
   const view = new TextPreviewEditorView({
@@ -11,6 +12,7 @@ function createTextPreviewEditorComponent({ root, props = {}, callbacks = {}, do
     controller,
     documentObj: resolvedDocumentObj,
     services: {
+      createRowCountControl: services.createRowCountControl || createRowCountControl,
       updateHelpHints: createUpdateHelpHints(resolvedDocumentObj, root),
     },
   });

--- a/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-controller.js
+++ b/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-controller.js
@@ -34,6 +34,11 @@ class TextPreviewEditorController {
     this.state.autoPreviewEnabled = enabled === true;
     this.callbacks.onAutoPreviewChange?.(this.state.autoPreviewEnabled);
   }
+
+  setPreviewRowLimit(previewRowLimit) {
+    this.state.previewRowLimit = previewRowLimit ?? 10;
+    this.callbacks.onPreviewRowLimitChange?.(this.state.previewRowLimit);
+  }
 }
 
 export { TextPreviewEditorController };

--- a/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-controller.js
+++ b/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-controller.js
@@ -1,3 +1,11 @@
+function normalizePreviewRowLimit(previewRowLimit) {
+  const parsedPreviewRowLimit = Number.parseInt(previewRowLimit, 10);
+  if (!Number.isFinite(parsedPreviewRowLimit)) {
+    return 10;
+  }
+  return Math.min(Math.max(parsedPreviewRowLimit, 1), 50);
+}
+
 class TextPreviewEditorController {
   constructor({ props = {}, callbacks = {} } = {}) {
     this.callbacks = callbacks;
@@ -5,7 +13,7 @@ class TextPreviewEditorController {
       'Edit mode shows the full grid text in the chosen format. You can edit this text and use Set Grid From Text to apply changes back into the grid.';
     this.state = {
       mode: props.mode || 'preview',
-      previewRowLimit: props.previewRowLimit ?? 10,
+      previewRowLimit: normalizePreviewRowLimit(props.previewRowLimit),
       autoPreviewEnabled: props.autoPreviewEnabled === true,
     };
   }
@@ -19,7 +27,7 @@ class TextPreviewEditorController {
       this.state.mode = nextProps.mode || 'preview';
     }
     if (Object.prototype.hasOwnProperty.call(nextProps, 'previewRowLimit')) {
-      this.state.previewRowLimit = nextProps.previewRowLimit ?? 10;
+      this.state.previewRowLimit = normalizePreviewRowLimit(nextProps.previewRowLimit);
     }
     if (Object.prototype.hasOwnProperty.call(nextProps, 'autoPreviewEnabled')) {
       this.state.autoPreviewEnabled = nextProps.autoPreviewEnabled === true;
@@ -36,9 +44,9 @@ class TextPreviewEditorController {
   }
 
   setPreviewRowLimit(previewRowLimit) {
-    this.state.previewRowLimit = previewRowLimit ?? 10;
+    this.state.previewRowLimit = normalizePreviewRowLimit(previewRowLimit);
     this.callbacks.onPreviewRowLimitChange?.(this.state.previewRowLimit);
   }
 }
 
-export { TextPreviewEditorController };
+export { normalizePreviewRowLimit, TextPreviewEditorController };

--- a/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-view.js
+++ b/packages/core-ui/js/gui_components/app/text-preview-editor/text-preview-editor-view.js
@@ -6,6 +6,7 @@ class TextPreviewEditorView {
     this.controller = controller;
     this.documentObj = resolveDocumentObj(documentObj, root);
     this.services = services;
+    this.previewRowCountControl = null;
     this.handleModeClick = () => this.controller.toggleMode();
     this.handleAutoPreviewChange = (event) =>
       this.controller.setAutoPreviewEnabled(event?.currentTarget?.checked === true);
@@ -17,6 +18,7 @@ class TextPreviewEditorView {
     }
 
     this.root.innerHTML = this.template();
+    this.createControls();
     this.bindEvents();
     this.render();
     this.services.updateHelpHints?.();
@@ -38,6 +40,7 @@ class TextPreviewEditorView {
             class="helpicon option-help-icon"
           ></span>
           <button type="button" title="Toggle Preview/Edit mode" id="previewEditModeButton">Preview</button>
+          <span data-role="preview-row-count-root"></span>
           <button type="button" title="Copy text to clipboard" id="copyTextButton">Copy</button>
         </div>
       </div>
@@ -65,6 +68,39 @@ class TextPreviewEditorView {
     `;
   }
 
+  createControls() {
+    const createRowCountControl = this.services.createRowCountControl;
+    const rowCountRoot = this.root.querySelector('[data-role="preview-row-count-root"]');
+    if (rowCountRoot && typeof createRowCountControl === 'function') {
+      const state = this.controller.getState();
+      this.previewRowCountControl = createRowCountControl({
+        root: rowCountRoot,
+        documentObj: this.documentObj,
+        props: {
+          inputId: 'previewRowsCount',
+          label: '',
+          min: 1,
+          max: 50,
+          step: 1,
+          value: state.previewRowLimit,
+          normalizeOnInput: true,
+          clampToMaxOnInput: true,
+          inputAriaLabel: 'Preview row count',
+          className: 'app-preview-row-count-control',
+          labelClassName: 'generator-preview-count-label',
+        },
+        callbacks: {
+          onChange: ({ parsed }) => {
+            if (parsed?.valid) {
+              this.controller.setPreviewRowLimit(parsed.value);
+              this.render();
+            }
+          },
+        },
+      });
+    }
+  }
+
   bindEvents() {
     this.root.querySelector('#previewEditModeButton')?.addEventListener('click', this.handleModeClick);
     this.root.querySelector('#autoPreviewCheckbox')?.addEventListener('change', this.handleAutoPreviewChange);
@@ -77,12 +113,26 @@ class TextPreviewEditorView {
     const modeHelpIcon = this.root.querySelector('#previewEditModeHelpIcon');
 
     if (modeButton) {
-      modeButton.innerText = state.mode === 'preview' ? `Preview (${state.previewRowLimit})` : 'Edit';
+      modeButton.innerText = state.mode === 'preview' ? 'Preview' : 'Edit';
     }
     if (autoPreviewCheckbox) {
       autoPreviewCheckbox.checked = state.autoPreviewEnabled;
       autoPreviewCheckbox.disabled = state.mode !== 'preview';
     }
+    this.previewRowCountControl?.update?.({
+      inputId: 'previewRowsCount',
+      label: '',
+      min: 1,
+      max: 50,
+      step: 1,
+      value: state.previewRowLimit,
+      normalizeOnInput: true,
+      clampToMaxOnInput: true,
+      inputAriaLabel: 'Preview row count',
+      className: 'app-preview-row-count-control',
+      labelClassName: 'generator-preview-count-label',
+      disabled: state.mode !== 'preview',
+    });
     if (modeHelpIcon) {
       const previewHelpText =
         state.mode === 'preview'
@@ -97,6 +147,8 @@ class TextPreviewEditorView {
   destroy() {
     this.root.querySelector('#previewEditModeButton')?.removeEventListener('click', this.handleModeClick);
     this.root.querySelector('#autoPreviewCheckbox')?.removeEventListener('change', this.handleAutoPreviewChange);
+    this.previewRowCountControl?.destroy?.();
+    this.previewRowCountControl = null;
     this.root.replaceChildren();
   }
 

--- a/packages/core-ui/js/gui_components/shared/row-count-control/row-count-control-controller.js
+++ b/packages/core-ui/js/gui_components/shared/row-count-control/row-count-control-controller.js
@@ -18,6 +18,7 @@ function normalizeProps(props = {}) {
     clampToMaxOnInput: props.clampToMaxOnInput === true,
     className: props.className || 'row-count-control',
     inputClassName: props.inputClassName || '',
+    inputAriaLabel: props.inputAriaLabel || '',
     labelClassName: props.labelClassName || '',
   };
 }

--- a/packages/core-ui/js/gui_components/shared/row-count-control/row-count-control-view.js
+++ b/packages/core-ui/js/gui_components/shared/row-count-control/row-count-control-view.js
@@ -49,6 +49,11 @@ class RowCountControlView {
     this.inputElement.step = `${state.step}`;
     this.inputElement.disabled = state.disabled === true;
     this.inputElement.className = state.inputClassName;
+    if (state.inputAriaLabel) {
+      this.inputElement.setAttribute('aria-label', state.inputAriaLabel);
+    } else {
+      this.inputElement.removeAttribute('aria-label');
+    }
     if (Number.isFinite(state.max)) {
       this.inputElement.max = `${state.max}`;
     } else {

--- a/packages/core-ui/src/tests/app/import-export-workspace.test.js
+++ b/packages/core-ui/src/tests/app/import-export-workspace.test.js
@@ -24,7 +24,10 @@ describe('ImportExportWorkspace', () => {
       setOptionsViewForFormatType: jest.fn(),
       toggleTextEditMode: jest.fn(async () => 'edit'),
       _syncGridFromTextButtonState: jest.fn(),
-      setPreviewRowLimit: jest.fn(),
+      setPreviewRowLimit: jest.fn((value) => {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), 50) : 10;
+      }),
       setExporter: jest.fn(),
       setImporter: jest.fn(),
       setGridChangeSource: jest.fn(),
@@ -58,6 +61,18 @@ describe('ImportExportWorkspace', () => {
 
     expect(component.getState().previewRowLimit).toBe(7);
     expect(legacyControls.setPreviewRowLimit).toHaveBeenLastCalledWith(7);
+
+    component.update({ previewRowLimit: 12 });
+
+    expect(component.getState().previewRowLimit).toBe(12);
+    expect(documentObj.querySelector('#previewRowsCount').value).toBe('12');
+    expect(legacyControls.setPreviewRowLimit).toHaveBeenLastCalledWith(12);
+
+    component.update({ previewRowLimit: 0 });
+
+    expect(component.getState().previewRowLimit).toBe(1);
+    expect(documentObj.querySelector('#previewRowsCount').value).toBe('1');
+    expect(legacyControls.setPreviewRowLimit).toHaveBeenLastCalledWith(0);
   });
 
   test('can mount from the root ownerDocument without a global document', () => {
@@ -78,7 +93,7 @@ describe('ImportExportWorkspace', () => {
             setOptionsViewForFormatType: jest.fn(),
             toggleTextEditMode: jest.fn(async () => 'edit'),
             _syncGridFromTextButtonState: jest.fn(),
-            setPreviewRowLimit: jest.fn(),
+            setPreviewRowLimit: jest.fn((value) => value),
             destroy: jest.fn(),
           },
         },

--- a/packages/core-ui/src/tests/app/import-export-workspace.test.js
+++ b/packages/core-ui/src/tests/app/import-export-workspace.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { jest } from '@jest/globals';
+import { fireEvent } from '@testing-library/dom';
 import { createImportExportWorkspaceComponent } from '../../../js/gui_components/app/import-export-workspace/index.js';
 
 describe('ImportExportWorkspace', () => {
@@ -23,6 +24,7 @@ describe('ImportExportWorkspace', () => {
       setOptionsViewForFormatType: jest.fn(),
       toggleTextEditMode: jest.fn(async () => 'edit'),
       _syncGridFromTextButtonState: jest.fn(),
+      setPreviewRowLimit: jest.fn(),
       setExporter: jest.fn(),
       setImporter: jest.fn(),
       setGridChangeSource: jest.fn(),
@@ -38,7 +40,10 @@ describe('ImportExportWorkspace', () => {
 
     expect(documentObj.querySelector('#tabbedTextArea')).not.toBeNull();
     expect(documentObj.querySelector('#settextfromgridbutton')).not.toBeNull();
+    expect(documentObj.querySelector('#previewRowsCount')).not.toBeNull();
+    expect(documentObj.querySelector('#previewRowsCount').getAttribute('aria-label')).toBe('Preview row count');
     expect(legacyControls.bindExistingGui).toHaveBeenCalledTimes(1);
+    expect(legacyControls.setPreviewRowLimit).toHaveBeenCalledWith(10);
 
     documentObj.querySelector('.type-select-action[data-type="json"]')?.click();
 
@@ -46,6 +51,13 @@ describe('ImportExportWorkspace', () => {
     expect(legacyControls.setFileFormatType).toHaveBeenCalledTimes(1);
     expect(legacyControls.setOptionsViewForFormatType).toHaveBeenCalledTimes(1);
     expect(component.getState().selectedFormat).toBe('json');
+
+    const previewRowCount = documentObj.querySelector('#previewRowsCount');
+    previewRowCount.value = '7';
+    fireEvent.input(previewRowCount, { target: { value: '7' } });
+
+    expect(component.getState().previewRowLimit).toBe(7);
+    expect(legacyControls.setPreviewRowLimit).toHaveBeenLastCalledWith(7);
   });
 
   test('can mount from the root ownerDocument without a global document', () => {
@@ -66,6 +78,7 @@ describe('ImportExportWorkspace', () => {
             setOptionsViewForFormatType: jest.fn(),
             toggleTextEditMode: jest.fn(async () => 'edit'),
             _syncGridFromTextButtonState: jest.fn(),
+            setPreviewRowLimit: jest.fn(),
             destroy: jest.fn(),
           },
         },

--- a/packages/core-ui/src/tests/app/text-preview-editor-controller.test.js
+++ b/packages/core-ui/src/tests/app/text-preview-editor-controller.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+import { TextPreviewEditorController } from '../../../js/gui_components/app/text-preview-editor/text-preview-editor-controller.js';
+
+describe('TextPreviewEditorController', () => {
+  test('normalizes preview row limit props and updates into the supported 1..50 range', () => {
+    const onPreviewRowLimitChange = jest.fn();
+    const controller = new TextPreviewEditorController({
+      props: {
+        previewRowLimit: 0,
+      },
+      callbacks: {
+        onPreviewRowLimitChange,
+      },
+    });
+
+    expect(controller.getState().previewRowLimit).toBe(1);
+
+    controller.setPreviewRowLimit(99);
+    expect(controller.getState().previewRowLimit).toBe(50);
+    expect(onPreviewRowLimitChange).toHaveBeenLastCalledWith(50);
+
+    controller.setPreviewRowLimit('abc');
+    expect(controller.getState().previewRowLimit).toBe(10);
+    expect(onPreviewRowLimitChange).toHaveBeenLastCalledWith(10);
+
+    controller.updateProps({ previewRowLimit: 12 });
+    expect(controller.getState().previewRowLimit).toBe(12);
+  });
+});

--- a/packages/core-ui/src/tests/app/text-preview-editor.test.js
+++ b/packages/core-ui/src/tests/app/text-preview-editor.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { JSDOM } from 'jsdom';
+import { fireEvent } from '@testing-library/dom';
 import { createTextPreviewEditorComponent } from '../../../js/gui_components/app/text-preview-editor/index.js';
 
 describe('TextPreviewEditor', () => {
@@ -22,7 +23,7 @@ describe('TextPreviewEditor', () => {
     jest.restoreAllMocks();
   });
 
-  test('binds tooltip help on mount and updates preview mode help text', () => {
+  test('binds tooltip help on mount, renders preview row control, and updates preview mode help text', () => {
     const component = createTextPreviewEditorComponent({
       root,
       documentObj,
@@ -34,18 +35,33 @@ describe('TextPreviewEditor', () => {
     });
 
     const helpIcon = root.querySelector('#previewEditModeHelpIcon');
+    const previewRowCount = root.querySelector('#previewRowsCount');
+    const previewButton = root.querySelector('#previewEditModeButton');
 
     expect(global.tippy).toHaveBeenCalled();
     expect(helpIcon.getAttribute('role')).toBe('button');
     expect(helpIcon.getAttribute('aria-label')).toBe('Show help for this option');
+    expect(previewRowCount).not.toBeNull();
+    expect(previewRowCount.value).toBe('10');
+    expect(previewRowCount.getAttribute('aria-label')).toBe('Preview row count');
+    expect(previewRowCount.min).toBe('1');
+    expect(root.textContent).not.toContain('Preview Items Count');
+    expect(previewButton.innerText).toBe('Preview');
     expect(helpIcon.getAttribute('data-help-text')).toContain('first 10 rows');
+
+    previewRowCount.value = '7';
+    fireEvent.input(previewRowCount, { target: { value: '7' } });
+
+    expect(helpIcon.getAttribute('data-help-text')).toContain('first 7 rows');
 
     component.update({
       mode: 'edit',
-      previewRowLimit: 10,
+      previewRowLimit: 7,
       autoPreviewEnabled: false,
     });
 
     expect(helpIcon.getAttribute('data-help-text')).toContain('Edit mode');
+    expect(previewButton.innerText).toBe('Edit');
+    expect(previewRowCount.disabled).toBe(true);
   });
 });

--- a/packages/core-ui/src/tests/app/text-preview-editor.test.js
+++ b/packages/core-ui/src/tests/app/text-preview-editor.test.js
@@ -3,6 +3,10 @@ import { JSDOM } from 'jsdom';
 import { fireEvent } from '@testing-library/dom';
 import { createTextPreviewEditorComponent } from '../../../js/gui_components/app/text-preview-editor/index.js';
 
+function getRenderedButtonText(button) {
+  return button?.innerText ?? button?.textContent?.trim() ?? '';
+}
+
 describe('TextPreviewEditor', () => {
   let dom;
   let documentObj;
@@ -46,7 +50,7 @@ describe('TextPreviewEditor', () => {
     expect(previewRowCount.getAttribute('aria-label')).toBe('Preview row count');
     expect(previewRowCount.min).toBe('1');
     expect(root.textContent).not.toContain('Preview Items Count');
-    expect(previewButton.innerText).toBe('Preview');
+    expect(getRenderedButtonText(previewButton)).toBe('Preview');
     expect(helpIcon.getAttribute('data-help-text')).toContain('first 10 rows');
 
     previewRowCount.value = '7';
@@ -61,7 +65,7 @@ describe('TextPreviewEditor', () => {
     });
 
     expect(helpIcon.getAttribute('data-help-text')).toContain('Edit mode');
-    expect(previewButton.innerText).toBe('Edit');
+    expect(getRenderedButtonText(previewButton)).toBe('Edit');
     expect(previewRowCount.disabled).toBe(true);
   });
 });

--- a/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
+++ b/packages/core-ui/src/tests/utils/import-export-controls-mode.test.js
@@ -94,6 +94,21 @@ describe('ImportExportControls preview/edit mode', () => {
     expect(controls.exportControls.setTextFromString).toHaveBeenCalledWith('rows:10');
   });
 
+  test('updates preview row limit at runtime for preview-limited rendering paths', async () => {
+    controls.setPreviewRowLimit(4);
+
+    controls.renderTextFromGrid();
+    let previewTable = controls.exporter.getDataTableAs.mock.calls.at(-1)[1];
+    expect(previewTable.getRowCount()).toBe(4);
+
+    controls.importer.toGenericDataTable.mockReturnValue(makeDataTable(12));
+    await controls._previewThenImportToGrid('csv', 'sample-text');
+
+    previewTable = controls.exporter.getDataTableAs.mock.calls.at(-1)[1];
+    expect(previewTable.getRowCount()).toBe(4);
+    expect(document.getElementById('import-progress-status').textContent).toBe('Import complete.');
+  });
+
   test('toggle to edit with confirm false clears textarea for manual editing', async () => {
     requestConfirm.mockResolvedValue(false);
     await controls.toggleTextEditMode();


### PR DESCRIPTION
closes #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preview row-count control (1–50) with a default of 10 to let reviewers choose how many rows show in preview mode.

* **UI Updates**
  * Preview button label standardized to "Preview" (row count shown only in the spinbutton).
  * Row-count input made more compact and integrated into the preview/editor panel.
  * Changing the control updates preview output immediately.

* **Accessibility**
  * Preview row-count input exposes/upkeeps ARIA labels and relevant attributes.

* **Tests**
  * Expanded interaction and unit tests to validate preview row-limit behavior and UI flows.

* **Documentation**
  * Added a frontend legacy-ui migration plan document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->