### PR TITLE
[codex] Fix testenv site page header rendering

### DIFF
--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -503,6 +503,11 @@ function hideTopHeaderInBuiltHtml(html) {
 async function hideTopHeaderInBuiltPage(pagePath) {
   const html = await readFile(pagePath, 'utf8');
   const nextHtml = hideTopHeaderInBuiltHtml(html);
+
+  if (nextHtml === html) {
+    return;
+  }
+
   await writeFile(pagePath, nextHtml, 'utf8');
 }
 

--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -64,7 +64,7 @@ function runCommand(command, args, options = {}) {
 
   if (result.status !== 0) {
     throw new Error(
-      `Command failed: ${command} ${args.join(' ')} (status ${result.status ?? 1}${result.signal ? `, signal ${result.signal}` : ''})`,
+      `Command failed: ${command} ${args.join(' ')} (status ${result.status ?? 1}${result.signal ? `, signal ${result.signal}` : ''})`
     );
   }
 }
@@ -191,10 +191,7 @@ function upsertHeadStyle(html, markerAttribute, styleTag) {
 
 function applySeoDirectivesToHtml(
   html,
-  {
-    canonicalUrl = ROOT_CANONICAL_URL,
-    robotsDirectives = TESTENV_ROBOTS_DIRECTIVES,
-  } = {},
+  { canonicalUrl = ROOT_CANONICAL_URL, robotsDirectives = TESTENV_ROBOTS_DIRECTIVES } = {}
 ) {
   let nextHtml = html;
 
@@ -495,13 +492,17 @@ const TESTENV_HIDE_HEADER_STYLE = `
       }
     </style>`;
 
-async function hideTopHeaderInBuiltPage(pagePath) {
-  const html = await readFile(pagePath, 'utf8');
+function hideTopHeaderInBuiltHtml(html) {
   if (html.includes('data-testenv-hide-header')) {
-    return;
+    return html;
   }
 
-  const nextHtml = html.replace('</head>', `${TESTENV_HIDE_HEADER_STYLE}\n  </head>`);
+  return html.replace('</head>', `${TESTENV_HIDE_HEADER_STYLE}\n  </head>`);
+}
+
+async function hideTopHeaderInBuiltPage(pagePath) {
+  const html = await readFile(pagePath, 'utf8');
+  const nextHtml = hideTopHeaderInBuiltHtml(html);
   await writeFile(pagePath, nextHtml, 'utf8');
 }
 
@@ -541,11 +542,7 @@ async function createTemporaryDocsAppPlaceholder() {
 }
 
 async function removeTemporaryDocsAppPlaceholder() {
-  await writeFile(
-    docsAppPlaceholderPath,
-    '<p>This will be overwritten during the npm build.</p>',
-    'utf8',
-  );
+  await writeFile(docsAppPlaceholderPath, '<p>This will be overwritten during the npm build.</p>', 'utf8');
 }
 
 async function main() {
@@ -578,26 +575,19 @@ async function main() {
   await createTemporaryDocsAppPlaceholder();
 
   try {
-    runCommand(
-      'pnpm',
-      ['--dir', 'docs-src', 'exec', 'docusaurus', 'build', '--out-dir', '../testenv/site'],
-      {
-        env: {
-          DOCS_BASE_URL: fullSiteBaseUrl,
-          DOCS_SITE_URL: 'https://eviltester.github.io',
-          DOCS_TEST_BUILD: 'true',
-          DOCS_TEST_CANONICAL_SITE_URL: TESTENV_CANONICAL_SITE_URL,
-        },
+    runCommand('pnpm', ['--dir', 'docs-src', 'exec', 'docusaurus', 'build', '--out-dir', '../testenv/site'], {
+      env: {
+        DOCS_BASE_URL: fullSiteBaseUrl,
+        DOCS_SITE_URL: 'https://eviltester.github.io',
+        DOCS_TEST_BUILD: 'true',
+        DOCS_TEST_CANONICAL_SITE_URL: TESTENV_CANONICAL_SITE_URL,
       },
-    );
+    });
   } finally {
     await removeTemporaryDocsAppPlaceholder();
   }
 
   await copyWebBuildIntoDirectory(tempWebDir, fullSiteDir);
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'app.html'));
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'generator.html'));
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'combinatorial.html'));
   await rm(tempWebDir, {
     recursive: true,
     force: true,
@@ -627,6 +617,7 @@ export {
   createLlmsTxt,
   createSiteRobotsTxt,
   createTestenvRobotsTxt,
+  hideTopHeaderInBuiltHtml,
   renderIndexPage,
 };
 

--- a/tests/integration/create-testenv-seo.test.js
+++ b/tests/integration/create-testenv-seo.test.js
@@ -5,6 +5,7 @@ import {
   createLlmsTxt,
   createSiteRobotsTxt,
   createTestenvRobotsTxt,
+  hideTopHeaderInBuiltHtml,
   renderIndexPage,
 } from '../../scripts/create-testenv.mjs';
 
@@ -47,7 +48,9 @@ describe('create-testenv SEO helpers', () => {
   });
 
   test('injects the test environment indicator into rewritten html pages', () => {
-    const html = applySeoDirectivesToHtml('<!doctype html><html><head><title>Storybook</title></head><body></body></html>');
+    const html = applySeoDirectivesToHtml(
+      '<!doctype html><html><head><title>Storybook</title></head><body></body></html>'
+    );
 
     expect(html).toContain('data-testenv-indicator');
     expect(html).toContain('content: "Test Environment"');
@@ -56,5 +59,44 @@ describe('create-testenv SEO helpers', () => {
     expect(html).toContain('border: 0;');
     expect(html).toContain('box-shadow: none;');
     expect(html).toContain('font: 700 6px/1.2 Arial, Helvetica, sans-serif;');
+  });
+
+  test('site page SEO rewrite preserves the visible navbar while adding the test environment indicator', () => {
+    const sourceHtml = `
+      <!doctype html>
+      <html>
+        <head><title>App</title></head>
+        <body>
+          <div class="header" data-role="theme-toggle-host">AnyWayData</div>
+        </body>
+      </html>
+    `;
+
+    const html = applySeoDirectivesToHtml(sourceHtml, {
+      canonicalUrl: `${TESTENV_CANONICAL_SITE_URL}/app.html`,
+    });
+
+    expect(html).toContain('data-testenv-indicator');
+    expect(html).toContain('class="header"');
+    expect(html).not.toContain('data-testenv-hide-header');
+    expect(html).toContain('<link rel="canonical" href="https://anywaydata.com/app.html" />');
+  });
+
+  test('standalone app pages can be rewritten to hide the top header', () => {
+    const sourceHtml = `
+      <!doctype html>
+      <html>
+        <head><title>Standalone App</title></head>
+        <body>
+          <div class="header" data-role="theme-toggle-host">AnyWayData</div>
+        </body>
+      </html>
+    `;
+
+    const html = hideTopHeaderInBuiltHtml(sourceHtml);
+
+    expect(html).toContain('data-testenv-hide-header');
+    expect(html).toContain('.header {');
+    expect(html).toContain('display: none !important;');
   });
 });

--- a/tests/integration/create-testenv-seo.test.js
+++ b/tests/integration/create-testenv-seo.test.js
@@ -61,7 +61,7 @@ describe('create-testenv SEO helpers', () => {
     expect(html).toContain('font: 700 6px/1.2 Arial, Helvetica, sans-serif;');
   });
 
-  test('site page SEO rewrite preserves the visible navbar while adding the test environment indicator', () => {
+  test('SEO rewrite keeps existing headers intact while adding the test environment indicator', () => {
     const sourceHtml = `
       <!doctype html>
       <html>


### PR DESCRIPTION
## What changed
- keep the generated testenv root pages headerless for distraction-free standalone previews
- preserve the normal navbar on copied `/site/*.html` pages in the full-site test environment
- add regression coverage for both rendering paths in the testenv SEO integration tests

## Why this changed
The test environment builder was hiding the top header on both the standalone root pages and the copied `/site/` pages. That removed the expected navbar from `/site/app.html`, `/site/generator.html`, and related pages even though those pages should behave like the published site and keep the test-environment badge.

## Impact
Reviewers can now use the `/site/*.html` pages with normal navigation intact, while the standalone experiment pages still stay minimal.

## Validation
- `pnpm test -- --runTestsByPath tests/integration/create-testenv-seo.test.js`
- `pnpm run verify:ui`
- `pnpm run verify:local`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test coverage for SEO directives and header management
  * Added tests verifying markup preservation and header-hiding functionality

* **Refactor**
  * Improved code structure and maintainability in test environment setup scripts
  * Streamlined helper function organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->