### PR TITLE
[codex] Fix test env webmcp and site chrome

### DIFF
--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -604,6 +604,9 @@ async function main() {
   await applySeoDirectivesToFile(path.join(fullSiteDir, 'combinatorial.html'), {
     canonicalUrl: ROOT_PAGE_CANONICALS['combinatorial.html'],
   });
+  await applySeoDirectivesToFile(path.join(fullSiteDir, 'webmcp.html'), {
+    canonicalUrl: ROOT_PAGE_CANONICALS['webmcp.html'],
+  });
   await rm(tempWebDir, {
     recursive: true,
     force: true,

--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -25,6 +25,7 @@ const ROOT_PAGE_CANONICALS = {
   'app.html': `${TESTENV_CANONICAL_SITE_URL}/app.html`,
   'generator.html': `${TESTENV_CANONICAL_SITE_URL}/generator.html`,
   'combinatorial.html': `${TESTENV_CANONICAL_SITE_URL}/combinatorial.html`,
+  'webmcp.html': `${TESTENV_CANONICAL_SITE_URL}/webmcp.html`,
 };
 const TESTENV_INDICATOR_STYLE = `<style data-testenv-indicator>
       body::before {
@@ -272,6 +273,7 @@ Primary production URLs:
 - ${TESTENV_CANONICAL_SITE_URL}/app.html
 - ${TESTENV_CANONICAL_SITE_URL}/generator.html
 - ${TESTENV_CANONICAL_SITE_URL}/combinatorial.html
+- ${TESTENV_CANONICAL_SITE_URL}/webmcp.html
 - ${TESTENV_CANONICAL_SITE_URL}/docs/
 `;
 }

--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -495,13 +495,17 @@ const TESTENV_HIDE_HEADER_STYLE = `
       }
     </style>`;
 
-async function hideTopHeaderInBuiltPage(pagePath) {
-  const html = await readFile(pagePath, 'utf8');
+function applyTopHeaderHideToHtml(html) {
   if (html.includes('data-testenv-hide-header')) {
-    return;
+    return html;
   }
 
-  const nextHtml = html.replace('</head>', `${TESTENV_HIDE_HEADER_STYLE}\n  </head>`);
+  return html.replace('</head>', `${TESTENV_HIDE_HEADER_STYLE}\n  </head>`);
+}
+
+async function hideTopHeaderInBuiltPage(pagePath) {
+  const html = await readFile(pagePath, 'utf8');
+  const nextHtml = applyTopHeaderHideToHtml(html);
   await writeFile(pagePath, nextHtml, 'utf8');
 }
 
@@ -573,6 +577,7 @@ async function main() {
   await hideTopHeaderInBuiltPage(path.join(outputDir, 'app.html'));
   await hideTopHeaderInBuiltPage(path.join(outputDir, 'generator.html'));
   await hideTopHeaderInBuiltPage(path.join(outputDir, 'combinatorial.html'));
+  await hideTopHeaderInBuiltPage(path.join(outputDir, 'webmcp.html'));
 
   await mkdir(fullSiteDir, { recursive: true });
   await createTemporaryDocsAppPlaceholder();
@@ -595,9 +600,15 @@ async function main() {
   }
 
   await copyWebBuildIntoDirectory(tempWebDir, fullSiteDir);
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'app.html'));
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'generator.html'));
-  await hideTopHeaderInBuiltPage(path.join(fullSiteDir, 'combinatorial.html'));
+  await applySeoDirectivesToFile(path.join(fullSiteDir, 'app.html'), {
+    canonicalUrl: ROOT_PAGE_CANONICALS['app.html'],
+  });
+  await applySeoDirectivesToFile(path.join(fullSiteDir, 'generator.html'), {
+    canonicalUrl: ROOT_PAGE_CANONICALS['generator.html'],
+  });
+  await applySeoDirectivesToFile(path.join(fullSiteDir, 'combinatorial.html'), {
+    canonicalUrl: ROOT_PAGE_CANONICALS['combinatorial.html'],
+  });
   await rm(tempWebDir, {
     recursive: true,
     force: true,
@@ -624,6 +635,7 @@ export {
   TESTENV_CANONICAL_SITE_URL,
   TESTENV_ROBOTS_DIRECTIVES,
   applySeoDirectivesToHtml,
+  applyTopHeaderHideToHtml,
   createLlmsTxt,
   createSiteRobotsTxt,
   createTestenvRobotsTxt,

--- a/scripts/create-testenv.mjs
+++ b/scripts/create-testenv.mjs
@@ -496,11 +496,7 @@ const TESTENV_HIDE_HEADER_STYLE = `
     </style>`;
 
 function applyTopHeaderHideToHtml(html) {
-  if (html.includes('data-testenv-hide-header')) {
-    return html;
-  }
-
-  return html.replace('</head>', `${TESTENV_HIDE_HEADER_STYLE}\n  </head>`);
+  return upsertHeadStyle(html, 'data-testenv-hide-header', TESTENV_HIDE_HEADER_STYLE);
 }
 
 async function hideTopHeaderInBuiltPage(pagePath) {

--- a/tests/integration/create-testenv-seo.test.js
+++ b/tests/integration/create-testenv-seo.test.js
@@ -31,6 +31,7 @@ describe('create-testenv SEO helpers', () => {
 
     expect(llmsTxt).toContain('non-production review and test deployment');
     expect(llmsTxt).toContain(ROOT_CANONICAL_URL);
+    expect(llmsTxt).toContain(`${TESTENV_CANONICAL_SITE_URL}/webmcp.html`);
     expect(llmsTxt).toContain(`${TESTENV_CANONICAL_SITE_URL}/docs/`);
   });
 
@@ -107,6 +108,16 @@ describe('create-testenv SEO helpers', () => {
     expect(html).toContain('data-testenv-hide-header');
     expect(html).toContain('.header {');
     expect(html).toContain('display: none !important;');
+  });
+
+  test('SEO rewrite can target webmcp.html with canonical and test environment marker', () => {
+    const html = applySeoDirectivesToHtml('<!doctype html><html><head><title>WebMCP</title></head><body></body></html>', {
+      canonicalUrl: `${TESTENV_CANONICAL_SITE_URL}/webmcp.html`,
+    });
+
+    expect(html).toContain('data-testenv-indicator');
+    expect(html).toContain('<meta name="robots" content="noindex,nofollow,noarchive,nosnippet" />');
+    expect(html).toContain('<link rel="canonical" href="https://anywaydata.com/webmcp.html" />');
   });
 
   test('updates the existing top-level header-hiding style without duplicating it', () => {

--- a/tests/integration/create-testenv-seo.test.js
+++ b/tests/integration/create-testenv-seo.test.js
@@ -67,11 +67,13 @@ describe('create-testenv SEO helpers', () => {
     expect(html).toContain('display: none !important;');
   });
 
-  test('does not duplicate the top-level header-hiding style', () => {
+  test('updates the existing top-level header-hiding style without duplicating it', () => {
     const html = applyTopHeaderHideToHtml(
-      '<!doctype html><html><head><style data-testenv-hide-header>.header{display:none!important;}</style></head><body></body></html>',
+      '<!doctype html><html><head><style data-testenv-hide-header>.header{display:block!important;}</style></head><body></body></html>',
     );
 
     expect(html.match(/data-testenv-hide-header/g)).toHaveLength(1);
+    expect(html).toContain('display: none !important;');
+    expect(html).not.toContain('display:block!important;');
   });
 });

--- a/tests/integration/create-testenv-seo.test.js
+++ b/tests/integration/create-testenv-seo.test.js
@@ -2,6 +2,7 @@ import {
   ROOT_CANONICAL_URL,
   TESTENV_CANONICAL_SITE_URL,
   applySeoDirectivesToHtml,
+  applyTopHeaderHideToHtml,
   createLlmsTxt,
   createSiteRobotsTxt,
   createTestenvRobotsTxt,
@@ -56,5 +57,21 @@ describe('create-testenv SEO helpers', () => {
     expect(html).toContain('border: 0;');
     expect(html).toContain('box-shadow: none;');
     expect(html).toContain('font: 700 6px/1.2 Arial, Helvetica, sans-serif;');
+  });
+
+  test('adds the testenv header-hiding style for top-level published app pages', () => {
+    const html = applyTopHeaderHideToHtml('<!doctype html><html><head><title>WebMCP</title></head><body><div class="header"></div></body></html>');
+
+    expect(html).toContain('data-testenv-hide-header');
+    expect(html).toContain('.header {');
+    expect(html).toContain('display: none !important;');
+  });
+
+  test('does not duplicate the top-level header-hiding style', () => {
+    const html = applyTopHeaderHideToHtml(
+      '<!doctype html><html><head><style data-testenv-hide-header>.header{display:none!important;}</style></head><body></body></html>',
+    );
+
+    expect(html.match(/data-testenv-hide-header/g)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- hide the top header on the top-level test environment `webmcp.html` page so it behaves like the standalone app and generator test pages
- keep the `/site/app.html` and `/site/generator.html` navbar intact while still injecting the test environment indicator styles
- add integration coverage for the testenv header-hiding helper behavior

## Why
The test environment publish flow was stripping headers from nested `/site/*` pages that should retain the normal site navbar, while the standalone `webmcp.html` page was not getting the same no-navigation treatment as the other top-level test pages.

## Validation
- Skipped rerunning verification in this publish step per request
- Earlier in the working session, `pnpm run verify:local` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced SEO metadata handling with canonical URLs now included for webmcp.html in generated site references.
  * Refactored header-hiding transformations for consistency across published pages.

* **Tests**
  * Expanded test coverage for SEO directive application and header-hiding behavior.
  * Added tests verifying canonical URL inclusion and style rule deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->