### PR TITLE
Fix single-value explicit enum handling (#181)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -442,18 +442,43 @@ jobs:
             docker rm -f web-ci >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
+          web_curl() {
+            for attempt in {1..5}; do
+              if curl -fsS "$@"; then
+                return 0
+              fi
+              sleep 1
+            done
+            echo "Web smoke request failed after retries: curl $*"
+            docker ps -a --filter "name=web-ci" || true
+            docker logs web-ci || true
+            exit 1
+          }
 
           docker build -f apps/web/Dockerfile -t anywaydata-web-ci .
           docker run -d --rm --name web-ci -p 18080:80 anywaydata-web-ci
 
+          ready=0
           for i in {1..20}; do
+            if ! docker ps --format '{{.Names}}' | grep -q '^web-ci$'; then
+              echo "Web container exited before readiness check completed"
+              docker ps -a --filter "name=web-ci" || true
+              docker logs web-ci || true
+              exit 1
+            fi
             if curl -fsS http://127.0.0.1:18080/app.html >/dev/null; then
+              ready=1
               break
             fi
             sleep 1
           done
-          curl -fsS http://127.0.0.1:18080/app.html | grep -q "AnyWayData"
-          curl -fsS http://127.0.0.1:18080/generator.html | grep -q "AnyWayData"
+          if [ "$ready" -ne 1 ]; then
+            docker logs web-ci || true
+            echo "Web container did not become ready within timeout"
+            exit 1
+          fi
+          web_curl http://127.0.0.1:18080/app.html | grep -q "AnyWayData"
+          web_curl http://127.0.0.1:18080/generator.html | grep -q "AnyWayData"
           echo "Web docker smoke test passed"
 
       - name: Docker smoke test (AnyWayData full site)
@@ -464,16 +489,41 @@ jobs:
             docker rm -f site-ci >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
+          site_curl() {
+            for attempt in {1..5}; do
+              if curl -fsS "$@"; then
+                return 0
+              fi
+              sleep 1
+            done
+            echo "AnyWayData full-site smoke request failed after retries: curl $*"
+            docker ps -a --filter "name=site-ci" || true
+            docker logs site-ci || true
+            exit 1
+          }
 
           docker build -f apps/anywaydata/Dockerfile -t anywaydata-site-ci .
           docker run -d --rm --name site-ci -p 18081:8080 anywaydata-site-ci
 
+          ready=0
           for i in {1..20}; do
+            if ! docker ps --format '{{.Names}}' | grep -q '^site-ci$'; then
+              echo "AnyWayData full-site container exited before readiness check completed"
+              docker ps -a --filter "name=site-ci" || true
+              docker logs site-ci || true
+              exit 1
+            fi
             if curl -fsS http://127.0.0.1:18081/ >/dev/null; then
+              ready=1
               break
             fi
             sleep 1
           done
-          curl -fsS http://127.0.0.1:18081/ | grep -q "AnyWayData"
-          curl -fsS http://127.0.0.1:18081/app.html | grep -q "AnyWayData"
+          if [ "$ready" -ne 1 ]; then
+            docker logs site-ci || true
+            echo "AnyWayData full-site container did not become ready within timeout"
+            exit 1
+          fi
+          site_curl http://127.0.0.1:18081/ | grep -q "AnyWayData"
+          site_curl http://127.0.0.1:18081/app.html | grep -q "AnyWayData"
           echo "AnyWayData full-site docker smoke test passed"

--- a/packages/core/js/data_generation/enum/enumTestDataRuleValidator.js
+++ b/packages/core/js/data_generation/enum/enumTestDataRuleValidator.js
@@ -16,8 +16,7 @@ export class EnumTestDataRuleValidator {
 
       // Explicit enum(...) syntax supports a single value, while implicit CSV enums still need at least two.
       if (enumValues.length < minimumValues) {
-        this.validationError =
-          minimumValues === 1 ? 'Enum must have at least 1 value' : 'Enum must have at least 2 values';
+        this.validationError = `Enum must have at least ${minimumValues} value${minimumValues === 1 ? '' : 's'}`;
         return false;
       }
 

--- a/packages/core/js/data_generation/enum/enumTestDataRuleValidator.js
+++ b/packages/core/js/data_generation/enum/enumTestDataRuleValidator.js
@@ -1,4 +1,5 @@
 import { EnumParser } from '../utils/enumParser.js';
+import { isExplicitEnumRule } from '../utils/enum-rule-detection.js';
 
 export class EnumTestDataRuleValidator {
   constructor() {
@@ -11,10 +12,12 @@ export class EnumTestDataRuleValidator {
     try {
       const ruleSpec = String(aTestDataRule.ruleSpec || '');
       const enumValues = EnumParser.extractEnumValues(ruleSpec);
+      const minimumValues = isExplicitEnumRule(ruleSpec) ? 1 : 2;
 
-      // Must have at least 2 values
-      if (enumValues.length < 2) {
-        this.validationError = 'Enum must have at least 2 values';
+      // Explicit enum(...) syntax supports a single value, while implicit CSV enums still need at least two.
+      if (enumValues.length < minimumValues) {
+        this.validationError =
+          minimumValues === 1 ? 'Enum must have at least 1 value' : 'Enum must have at least 2 values';
         return false;
       }
 

--- a/packages/core/js/data_generation/utils/enumParser.js
+++ b/packages/core/js/data_generation/utils/enumParser.js
@@ -88,9 +88,7 @@ export class EnumParser {
         inQuotes = !inQuotes;
       } else if (char === ',' && !inQuotes) {
         // Found separator outside quotes
-        if (currentValue.trim().length > 0) {
-          values.push(currentValue.trim());
-        }
+        values.push(currentValue.trim());
         currentValue = '';
       } else {
         // Add character to current value
@@ -100,11 +98,9 @@ export class EnumParser {
     }
 
     // Add final value
-    if (currentValue.trim().length > 0) {
-      values.push(currentValue.trim());
-    }
+    values.push(currentValue.trim());
 
-    if (values.length === 0) {
+    if (values.length === 0 || values.every((value) => value.length === 0)) {
       throw new Error('No valid values found in enum');
     }
 

--- a/packages/core/src/tests/data_generation/enum-compiler-integration.test.js
+++ b/packages/core/src/tests/data_generation/enum-compiler-integration.test.js
@@ -18,6 +18,7 @@ describe('TestDataRulesCompiler with Enum Support', () => {
 
     test('detects awd enum formats', () => {
       expect(compiler.isEnumPattern('enum("A", "B")')).toBe(true);
+      expect(compiler.isEnumPattern('enum("A")')).toBe(true);
       expect(compiler.isEnumPattern('datatype.enum("Red", "Blue")')).toBe(true);
       expect(compiler.isEnumPattern('awd.datatype.enum("Small", "Large")')).toBe(true);
     });
@@ -47,6 +48,15 @@ describe('TestDataRulesCompiler with Enum Support', () => {
 
     test('compiles awd enum format correctly', () => {
       const rules = [new TestDataRule('Priority', 'datatype.enum("High", "Medium", "Low")')];
+
+      compiler.compile(rules);
+
+      expect(rules[0].type).toBe('enum');
+      expect(compiler.isValid()).toBe(true);
+    });
+
+    test('compiles explicit single-value enum correctly', () => {
+      const rules = [new TestDataRule('Status', 'enum("Open")')];
 
       compiler.compile(rules);
 

--- a/packages/core/src/tests/data_generation/enum-integration-e2e.test.js
+++ b/packages/core/src/tests/data_generation/enum-integration-e2e.test.js
@@ -40,6 +40,25 @@ datatype.enum("High", "Medium", "Low")`;
       });
     });
 
+    test('single-value explicit enum stays typed as enum and generates that value', () => {
+      const schemaText = `Status
+enum("Open")`;
+
+      const result = generateFromTextSpec({
+        textSpec: schemaText,
+        rowCount: 5,
+        outputFormat: 'json',
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.headers).toEqual(['Status']);
+      expect(result.rows).toHaveLength(5);
+
+      result.rows.forEach((row) => {
+        expect(row[0]).toBe('Open');
+      });
+    });
+
     test('mixed schema with enum, faker, and regex works', () => {
       const schemaText = `Name
 person.firstName

--- a/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
+++ b/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
@@ -91,6 +91,28 @@ describe('EnumTestDataRuleValidator', () => {
       expect(isValid).toBe(false);
       expect(validator.getValidationError()).toContain('Invalid enum format');
     });
+
+    test('rejects explicit enum with trailing empty argument', () => {
+      const rule = new TestDataRule('Bad', 'enum("OnlyOne",)');
+      rule.type = 'enum';
+
+      const validator = new EnumTestDataRuleValidator();
+      const isValid = validator.validate(rule);
+
+      expect(isValid).toBe(false);
+      expect(validator.getValidationError()).toContain('cannot be empty');
+    });
+
+    test('rejects explicit enum with empty argument between values', () => {
+      const rule = new TestDataRule('Bad', 'enum("One",,"Two")');
+      rule.type = 'enum';
+
+      const validator = new EnumTestDataRuleValidator();
+      const isValid = validator.validate(rule);
+
+      expect(isValid).toBe(false);
+      expect(validator.getValidationError()).toContain('cannot be empty');
+    });
   });
 
   describe('extractAwdEnumValues', () => {
@@ -122,6 +144,18 @@ describe('EnumTestDataRuleValidator', () => {
       const values = EnumParser.extractAwdEnumValues('enum("Open")');
 
       expect(values).toEqual(['Open']);
+    });
+
+    test('preserves trailing empty explicit enum arguments for validation', () => {
+      const values = EnumParser.extractAwdEnumValues('enum("Open",)');
+
+      expect(values).toEqual(['Open', '']);
+    });
+
+    test('preserves empty explicit enum arguments between commas for validation', () => {
+      const values = EnumParser.extractAwdEnumValues('enum("Open",,"Closed")');
+
+      expect(values).toEqual(['Open', '', 'Closed']);
     });
 
     test('extracts shorthand enum values without parentheses', () => {

--- a/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
+++ b/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
@@ -59,6 +59,17 @@ describe('EnumTestDataRuleValidator', () => {
       expect(validator.isValid()).toBe(true);
     });
 
+    test('accepts explicit enum syntax with one unquoted numeric value', () => {
+      const rule = new TestDataRule('Single', 'enum(10)');
+      rule.type = 'enum';
+
+      const validator = new EnumTestDataRuleValidator();
+      const isValid = validator.validate(rule);
+
+      expect(isValid).toBe(true);
+      expect(validator.isValid()).toBe(true);
+    });
+
     test('rejects enum with only one value', () => {
       const rule = new TestDataRule('Single', 'OnlyOne');
       rule.type = 'enum';
@@ -144,6 +155,12 @@ describe('EnumTestDataRuleValidator', () => {
       const values = EnumParser.extractAwdEnumValues('enum("Open")');
 
       expect(values).toEqual(['Open']);
+    });
+
+    test('extracts a single explicit unquoted numeric enum value', () => {
+      const values = EnumParser.extractAwdEnumValues('enum(10)');
+
+      expect(values).toEqual(['10']);
     });
 
     test('preserves trailing empty explicit enum arguments for validation', () => {

--- a/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
+++ b/packages/core/src/tests/data_generation/unit/enum/enumTestDataRuleValidator.test.js
@@ -48,6 +48,17 @@ describe('EnumTestDataRuleValidator', () => {
       expect(validator.isValid()).toBe(true);
     });
 
+    test('accepts explicit enum syntax with one value', () => {
+      const rule = new TestDataRule('Single', 'enum("OnlyOne")');
+      rule.type = 'enum';
+
+      const validator = new EnumTestDataRuleValidator();
+      const isValid = validator.validate(rule);
+
+      expect(isValid).toBe(true);
+      expect(validator.isValid()).toBe(true);
+    });
+
     test('rejects enum with only one value', () => {
       const rule = new TestDataRule('Single', 'OnlyOne');
       rule.type = 'enum';
@@ -105,6 +116,12 @@ describe('EnumTestDataRuleValidator', () => {
       const values = EnumParser.extractAwdEnumValues('enum(basic,"with space",advanced)');
 
       expect(values).toEqual(['basic', 'with space', 'advanced']);
+    });
+
+    test('extracts a single explicit enum value', () => {
+      const values = EnumParser.extractAwdEnumValues('enum("Open")');
+
+      expect(values).toEqual(['Open']);
     });
 
     test('extracts shorthand enum values without parentheses', () => {


### PR DESCRIPTION
## Summary
- allow explicit enum syntax like `enum("Open")` and `enum(10)` to validate as enums with a single value
- keep implicit comma-separated enum detection requiring at least two values so plain single values still do not become enums
- add validator, compiler, and end-to-end regression coverage for single-value explicit enums

## Root cause
Explicit enum syntax was detected correctly, but enum validation still enforced a minimum of two values for every enum form. That caused `enum(...)` with a single value to fall back to a literal.

## Validation
- `pnpm run verify:local`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-value enums using explicit `enum(...)` syntax are now supported, removing the previous minimum value requirement for explicit enum definitions.

* **Tests**
  * Added comprehensive test coverage for single-value enum validation, compilation, and end-to-end scenarios to ensure correct handling and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->