### PR TITLE
Add shared schema acceptance tests

### DIFF
--- a/apps/api/src/tests/fromschema/schema-acceptance.spec.js
+++ b/apps/api/src/tests/fromschema/schema-acceptance.spec.js
@@ -9,6 +9,8 @@ const {
 const { normalizeApiBody } = require('../../../../../tests/integration/support/schema-acceptance-assertions.cjs');
 
 test.describe('POST /v1/generate/fromschema schema acceptance', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeAll(async () => {
     await setupApiServer();
   });
@@ -16,8 +18,6 @@ test.describe('POST /v1/generate/fromschema schema acceptance', () => {
   test.afterAll(async () => {
     await teardownApiServer();
   });
-
-  test.describe.configure({ mode: 'serial' });
 
   for (const scenario of SCHEMA_ACCEPTANCE_SCENARIOS) {
     test(`${scenario.id} matches shared acceptance criteria`, async ({ request }) => {

--- a/apps/api/src/tests/fromschema/schema-acceptance.spec.js
+++ b/apps/api/src/tests/fromschema/schema-acceptance.spec.js
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import { setupApiServer, teardownApiServer, apiUrl } from '../api-test-setup.js';
+
+const require = createRequire(import.meta.url);
+const {
+  SCHEMA_ACCEPTANCE_SCENARIOS,
+} = require('../../../../../tests/integration/support/schema-acceptance-fixtures.cjs');
+const { normalizeApiBody } = require('../../../../../tests/integration/support/schema-acceptance-assertions.cjs');
+
+test.describe('POST /v1/generate/fromschema schema acceptance', () => {
+  test.beforeAll(async () => {
+    await setupApiServer();
+  });
+
+  test.afterAll(async () => {
+    await teardownApiServer();
+  });
+
+  test.describe.configure({ mode: 'serial' });
+
+  for (const scenario of SCHEMA_ACCEPTANCE_SCENARIOS) {
+    test(`${scenario.id} matches shared acceptance criteria`, async ({ request }) => {
+      const response = await request.post(
+        apiUrl(`/v1/generate/fromschema?rowCount=${scenario.rowCount}&outputFormat=${scenario.outputFormat}`),
+        {
+          data: scenario.schemaText,
+          headers: { 'content-type': 'text/plain' },
+        }
+      );
+
+      expect([200, 400]).toContain(response.status());
+      const body = await response.json();
+      const normalized = normalizeApiBody(body);
+      scenario.assertAcceptance(expect, normalized);
+    });
+  }
+});

--- a/apps/web/src/tests/browser/app/functional/test-data/schema-acceptance.spec.js
+++ b/apps/web/src/tests/browser/app/functional/test-data/schema-acceptance.spec.js
@@ -1,0 +1,53 @@
+const { test } = require('@playwright/test');
+const { openApp, expectNoPageErrors, expect } = require('../../abstractions/helpers/scenario-helpers');
+const {
+  SCHEMA_ACCEPTANCE_SCENARIOS,
+} = require('../../../../../../../../tests/integration/support/schema-acceptance-fixtures.cjs');
+const {
+  normalizeUiGridResult,
+  normalizeUiErrorText,
+} = require('../../../../../../../../tests/integration/support/schema-acceptance-assertions.cjs');
+
+async function readGridRows(appPage, headers) {
+  const rowCount = await appPage.gridEditor.renderer.countRows();
+  const columns = await Promise.all(headers.map((header) => appPage.gridEditor.renderer.getColumnTextsByName(header)));
+  const rows = [];
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+    rows.push(columns.map((column) => column[rowIndex]));
+  }
+  return rows;
+}
+
+test.describe('App test-data schema acceptance', () => {
+  for (const scenario of SCHEMA_ACCEPTANCE_SCENARIOS) {
+    test(`${scenario.id} matches shared acceptance criteria`, async ({ page }) => {
+      const { appPage, pageErrors } = await openApp(page);
+
+      await appPage.testDataPanel.expand();
+      await appPage.testDataPanel.expectExpanded();
+      await appPage.testDataPanel.setSchemaText(scenario.schemaText);
+
+      if (scenario.kind === 'good') {
+        await appPage.testDataPanel.setGenerateCount(scenario.rowCount);
+        await appPage.testDataPanel.clickGenerate();
+
+        await expect.poll(async () => appPage.gridEditor.renderer.countRows()).toBe(scenario.rowCount);
+        await expect.poll(async () => appPage.gridEditor.header.getColumnNames()).toEqual(scenario.expectedHeaders);
+
+        const rows = await readGridRows(appPage, scenario.expectedHeaders);
+        const normalized = normalizeUiGridResult({
+          headers: scenario.expectedHeaders,
+          rows,
+        });
+        scenario.assertAcceptance(expect, normalized);
+      } else {
+        await appPage.testDataPanel.clickGenerate();
+        await expect.poll(async () => await appPage.testDataPanel.getSchemaErrorText()).not.toBe('');
+        const normalized = normalizeUiErrorText(await appPage.testDataPanel.getSchemaErrorText());
+        scenario.assertAcceptance(expect, normalized);
+      }
+
+      expectNoPageErrors(pageErrors);
+    });
+  }
+});

--- a/apps/web/src/tests/browser/generator/functional/schema-acceptance.spec.js
+++ b/apps/web/src/tests/browser/generator/functional/schema-acceptance.spec.js
@@ -1,0 +1,44 @@
+const fs = require('node:fs');
+const { test } = require('@playwright/test');
+const { openGenerator, expectNoPageErrors, expect } = require('../abstractions/helpers/scenario-helpers');
+const {
+  SCHEMA_ACCEPTANCE_SCENARIOS,
+} = require('../../../../../../../tests/integration/support/schema-acceptance-fixtures.cjs');
+const {
+  normalizeUiDownloadedJson,
+  normalizeUiErrorText,
+} = require('../../../../../../../tests/integration/support/schema-acceptance-assertions.cjs');
+
+async function downloadGeneratedDataText(generatorPage) {
+  const download = await generatorPage.downloadGeneratedData();
+  const filePath = await download.path();
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+test.describe('Generator schema acceptance', () => {
+  for (const scenario of SCHEMA_ACCEPTANCE_SCENARIOS) {
+    test(`${scenario.id} matches shared acceptance criteria`, async ({ page }) => {
+      const { generatorPage, pageErrors } = await openGenerator(page);
+
+      await generatorPage.schema.setSchemaText(scenario.schemaText);
+
+      if (scenario.kind === 'good') {
+        await generatorPage.generateOptions.setRowsCount(scenario.rowCount);
+        await generatorPage.generateOptions.setOutputFormat(scenario.outputFormat);
+
+        const outputText = await downloadGeneratedDataText(generatorPage);
+        const normalized = normalizeUiDownloadedJson(outputText, scenario.expectedHeaders);
+        scenario.assertAcceptance(expect, normalized);
+      } else {
+        await generatorPage.preview.clickPreview();
+        await expect
+          .poll(async () => (await generatorPage.schema.errorStatus.textContent())?.trim() || '')
+          .not.toBe('');
+        const normalized = normalizeUiErrorText((await generatorPage.schema.errorStatus.textContent())?.trim() || '');
+        scenario.assertAcceptance(expect, normalized);
+      }
+
+      expectNoPageErrors(pageErrors);
+    });
+  }
+});

--- a/test-fixtures/schema-acceptance/bad/invalid-literal-constraint.schema.txt
+++ b/test-fixtures/schema-acceptance/bad/invalid-literal-constraint.schema.txt
@@ -1,0 +1,6 @@
+# Bad schema: the constraint contradicts the literal value.
+# All surfaces should reject this during validation/generation.
+Status
+literal(closed)
+
+IF [Status] = "closed" THEN [Status] = "open" ENDIF

--- a/test-fixtures/schema-acceptance/bad/missing-definition.schema.txt
+++ b/test-fixtures/schema-acceptance/bad/missing-definition.schema.txt
@@ -1,0 +1,4 @@
+# Bad schema: the field name is present but the rule definition is missing.
+# All surfaces should reject this and surface a "requires a data definition"
+# style validation error.
+OnlyName

--- a/test-fixtures/schema-acceptance/good/autoincrement-sequence.schema.txt
+++ b/test-fixtures/schema-acceptance/good/autoincrement-sequence.schema.txt
@@ -1,0 +1,4 @@
+# Good schema: autoIncrement.sequence should generate a deterministic
+# sequence when start, step, prefix, suffix, and zero padding are fixed.
+Ticket
+autoIncrement.sequence(start=1, step=5, prefix="T-", suffix=".txt", zeropadding=3)

--- a/test-fixtures/schema-acceptance/good/autoincrement-timestamp.schema.txt
+++ b/test-fixtures/schema-acceptance/good/autoincrement-timestamp.schema.txt
@@ -1,0 +1,4 @@
+# Good schema: autoIncrement.timestamp should generate deterministic
+# timestamps when the start time, step, type, and output format are fixed.
+Created At
+autoIncrement.timestamp(start="2026-06-12T12:39:23Z", step=2, type="days", outputFormat="yyyy-MM-dd")

--- a/test-fixtures/schema-acceptance/good/comments-and-enum.schema.txt
+++ b/test-fixtures/schema-acceptance/good/comments-and-enum.schema.txt
@@ -1,0 +1,9 @@
+# Good schema: comments and blank lines should be ignored consistently.
+# Priority is intentionally enum-based so acceptance checks validate
+# allowed values instead of one exact row ordering.
+Priority
+enum(high,medium,low)
+
+# This literal column gives one stable value across all rows.
+Status
+literal(active)

--- a/test-fixtures/schema-acceptance/good/deterministic-literals.schema.txt
+++ b/test-fixtures/schema-acceptance/good/deterministic-literals.schema.txt
@@ -1,0 +1,7 @@
+# Good schema: deterministic literals so every surface should generate
+# the same headers, row count, and values.
+First Name
+literal(Alice)
+
+Status
+literal(active)

--- a/tests/integration/cross-surface-schema-acceptance.test.js
+++ b/tests/integration/cross-surface-schema-acceptance.test.js
@@ -45,6 +45,31 @@ function requestMcpServer(payload) {
   return response;
 }
 
+function parseMcpScenarioPayload(response, scenarioId) {
+  if (response?.error) {
+    const code = response.error.code ?? 'unknown';
+    const message = response.error.message || JSON.stringify(response.error);
+    throw new Error(
+      `MCP JSON-RPC error for schema acceptance scenario "${scenarioId}" [${code}]: ${message}`
+    );
+  }
+
+  const text = response?.result?.content?.[0]?.text;
+  if (typeof text !== 'string' || text.trim() === '') {
+    throw new Error(
+      `MCP returned no result payload for schema acceptance scenario "${scenarioId}".`
+    );
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `MCP returned non-JSON payload for schema acceptance scenario "${scenarioId}": ${error.message}`
+    );
+  }
+}
+
 function runCliScenario(scenario) {
   const cliEntry = path.join(repoRoot, 'apps', 'cli', 'src', 'node-entry.js');
 
@@ -104,7 +129,7 @@ describe('cross-surface schema acceptance (CLI + MCP)', () => {
         },
       },
     });
-    const payload = JSON.parse(response?.result?.content?.[0]?.text || '{}');
+    const payload = parseMcpScenarioPayload(response, scenario.id);
     const normalized = normalizeMcpPayload(payload);
     scenario.assertAcceptance(expect, normalized);
   });

--- a/tests/integration/cross-surface-schema-acceptance.test.js
+++ b/tests/integration/cross-surface-schema-acceptance.test.js
@@ -1,0 +1,104 @@
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const CROSS_SURFACE_PROCESS_TIMEOUT_MS = 60000;
+
+const require = createRequire(import.meta.url);
+const {
+  repoRoot,
+  SCHEMA_ACCEPTANCE_SCENARIOS,
+} = require('./support/schema-acceptance-fixtures.cjs');
+const {
+  normalizeCliSuccess,
+  normalizeCliFailure,
+  normalizeMcpPayload,
+} = require('./support/schema-acceptance-assertions.cjs');
+
+function jsonRpcMessages(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('{'))
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function requestMcpServer(payload) {
+  const scriptPath = path.join(repoRoot, 'apps', 'mcp', 'src', 'index.js');
+  const output = execFileSync(process.execPath, [scriptPath], {
+    input: `${JSON.stringify(payload)}\n`,
+    encoding: 'utf8',
+    cwd: repoRoot,
+    // Full-suite runs can be CPU-bound; keep the cross-surface contract stable under load.
+    timeout: CROSS_SURFACE_PROCESS_TIMEOUT_MS,
+  });
+  const messages = jsonRpcMessages(output);
+  const response = messages.find((message) => message?.id === payload.id);
+  expect(response).toBeTruthy();
+  return response;
+}
+
+function runCliScenario(scenario) {
+  const cliEntry = path.join(repoRoot, 'apps', 'cli', 'src', 'node-entry.js');
+
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [
+        cliEntry,
+        'generate',
+        '-i',
+        scenario.schemaPath,
+        '-n',
+        String(scenario.rowCount),
+        '-f',
+        scenario.outputFormat,
+        '--show-progress',
+        'false',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        // Full-suite runs can be CPU-bound; keep the cross-surface contract stable under load.
+        timeout: CROSS_SURFACE_PROCESS_TIMEOUT_MS,
+      }
+    );
+
+    return normalizeCliSuccess(stdout, scenario.expectedHeaders);
+  } catch (error) {
+    return normalizeCliFailure(error.stderr || error.stdout || error.message);
+  }
+}
+
+describe('cross-surface schema acceptance (CLI + MCP)', () => {
+  test.each(SCHEMA_ACCEPTANCE_SCENARIOS)('$id CLI matches shared acceptance criteria', (scenario) => {
+    const normalized = runCliScenario(scenario);
+    scenario.assertAcceptance(expect, normalized);
+  });
+
+  test.each(SCHEMA_ACCEPTANCE_SCENARIOS)('$id MCP matches shared acceptance criteria', (scenario) => {
+    const response = requestMcpServer({
+      jsonrpc: '2.0',
+      id: `schema-acceptance-${scenario.id}`,
+      method: 'tools/call',
+      params: {
+        name: 'generate_data_from_spec',
+        arguments: {
+          textSpec: scenario.schemaText,
+          rowCount: scenario.rowCount,
+          outputFormat: scenario.outputFormat,
+        },
+      },
+    });
+    const payload = JSON.parse(response?.result?.content?.[0]?.text || '{}');
+    const normalized = normalizeMcpPayload(payload);
+    scenario.assertAcceptance(expect, normalized);
+  });
+});

--- a/tests/integration/cross-surface-schema-acceptance.test.js
+++ b/tests/integration/cross-surface-schema-acceptance.test.js
@@ -48,8 +48,9 @@ function requestMcpServer(payload) {
 function runCliScenario(scenario) {
   const cliEntry = path.join(repoRoot, 'apps', 'cli', 'src', 'node-entry.js');
 
+  let stdout;
   try {
-    const stdout = execFileSync(
+    stdout = execFileSync(
       process.execPath,
       [
         cliEntry,
@@ -70,10 +71,16 @@ function runCliScenario(scenario) {
         timeout: CROSS_SURFACE_PROCESS_TIMEOUT_MS,
       }
     );
-
-    return normalizeCliSuccess(stdout, scenario.expectedHeaders);
   } catch (error) {
     return normalizeCliFailure(error.stderr || error.stdout || error.message);
+  }
+
+  try {
+    return normalizeCliSuccess(stdout, scenario.expectedHeaders);
+  } catch (error) {
+    throw new Error(
+      `CLI returned non-JSON output for schema acceptance scenario "${scenario.id}": ${error.message}`
+    );
   }
 }
 

--- a/tests/integration/support/schema-acceptance-assertions.cjs
+++ b/tests/integration/support/schema-acceptance-assertions.cjs
@@ -22,6 +22,21 @@ function normalizeCellValue(value) {
   return String(value);
 }
 
+function inferObjectRowHeaders(parsedRows, fallbackHeaders = []) {
+  const discoveredHeaders = [];
+  for (const row of parsedRows) {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      continue;
+    }
+    for (const key of Object.keys(row)) {
+      if (!discoveredHeaders.includes(key)) {
+        discoveredHeaders.push(String(key));
+      }
+    }
+  }
+  return discoveredHeaders.length > 0 ? discoveredHeaders : fallbackHeaders.map(String);
+}
+
 function normalizeApiBody(body) {
   if (body?.headers && body?.rows) {
     return {
@@ -65,12 +80,13 @@ function normalizeMcpPayload(payload) {
   };
 }
 
-function normalizeCliSuccess(stdoutText, expectedHeaders) {
+function normalizeCliSuccess(stdoutText, fallbackHeaders = []) {
   const parsed = JSON.parse(stdoutText.trim());
+  const headers = inferObjectRowHeaders(parsed, fallbackHeaders);
   return {
     ok: true,
-    headers: expectedHeaders.map(String),
-    rows: toObjectRows(parsed, expectedHeaders),
+    headers,
+    rows: toObjectRows(parsed, headers),
     format: 'json',
     rendered: stdoutText.trim(),
     diagnostics: {},
@@ -109,12 +125,13 @@ function normalizeUiGridResult({ headers, rows }) {
   };
 }
 
-function normalizeUiDownloadedJson(text, expectedHeaders) {
+function normalizeUiDownloadedJson(text, fallbackHeaders = []) {
   const parsed = JSON.parse(text);
+  const headers = inferObjectRowHeaders(parsed, fallbackHeaders);
   return {
     ok: true,
-    headers: expectedHeaders.map(String),
-    rows: toObjectRows(parsed, expectedHeaders),
+    headers,
+    rows: toObjectRows(parsed, headers),
     format: 'json',
     rendered: text,
     diagnostics: {},

--- a/tests/integration/support/schema-acceptance-assertions.cjs
+++ b/tests/integration/support/schema-acceptance-assertions.cjs
@@ -1,0 +1,141 @@
+function toErrorParts(error) {
+  if (error && typeof error === 'object') {
+    return {
+      code: typeof error.code === 'string' ? error.code : '',
+      text: String(error.message || error.error || JSON.stringify(error)),
+    };
+  }
+  return {
+    code: '',
+    text: String(error || ''),
+  };
+}
+
+function toObjectRows(parsedRows, expectedHeaders) {
+  return parsedRows.map((row) => expectedHeaders.map((header) => normalizeCellValue(row?.[header])));
+}
+
+function normalizeCellValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}
+
+function normalizeApiBody(body) {
+  if (body?.headers && body?.rows) {
+    return {
+      ok: true,
+      headers: body.headers.map(String),
+      rows: body.rows.map((row) => row.map(normalizeCellValue)),
+      format: body.format || 'json',
+      rendered: typeof body.rendered === 'string' ? body.rendered : '',
+      diagnostics: body.diagnostics || {},
+    };
+  }
+
+  const parts = Array.isArray(body?.errors) ? body.errors.map(toErrorParts) : [];
+  return {
+    ok: false,
+    errorCodes: parts.map((part) => part.code).filter(Boolean),
+    errorTexts: parts.map((part) => part.text),
+    diagnostics: body?.diagnostics || {},
+  };
+}
+
+function normalizeMcpPayload(payload) {
+  if (payload?.ok === true && Array.isArray(payload.rows) && Array.isArray(payload.headers)) {
+    return {
+      ok: true,
+      headers: payload.headers.map(String),
+      rows: payload.rows.map((row) => row.map(normalizeCellValue)),
+      format: payload.format || 'json',
+      rendered: typeof payload.rendered === 'string' ? payload.rendered : '',
+      diagnostics: payload.diagnostics || {},
+    };
+  }
+
+  const detailErrors = Array.isArray(payload?.error?.details?.errors) ? payload.error.details.errors : [];
+  const parts = detailErrors.length > 0 ? detailErrors.map(toErrorParts) : [toErrorParts(payload?.error)];
+  return {
+    ok: false,
+    errorCodes: parts.map((part) => part.code).filter(Boolean),
+    errorTexts: parts.map((part) => part.text),
+    diagnostics: payload?.error?.details?.diagnostics || {},
+  };
+}
+
+function normalizeCliSuccess(stdoutText, expectedHeaders) {
+  const parsed = JSON.parse(stdoutText.trim());
+  return {
+    ok: true,
+    headers: expectedHeaders.map(String),
+    rows: toObjectRows(parsed, expectedHeaders),
+    format: 'json',
+    rendered: stdoutText.trim(),
+    diagnostics: {},
+  };
+}
+
+function normalizeCliFailure(stderrText) {
+  const parts = String(stderrText)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^\[([^\]]+)\]\s*(.*)$/);
+      return {
+        code: match ? match[1] : '',
+        text: match ? match[2] : line,
+      };
+    });
+
+  return {
+    ok: false,
+    errorCodes: parts.map((part) => part.code).filter(Boolean),
+    errorTexts: parts.map((part) => part.text),
+    diagnostics: {},
+  };
+}
+
+function normalizeUiGridResult({ headers, rows }) {
+  return {
+    ok: true,
+    headers: headers.map(String),
+    rows: rows.map((row) => row.map(normalizeCellValue)),
+    format: 'json',
+    rendered: '',
+    diagnostics: {},
+  };
+}
+
+function normalizeUiDownloadedJson(text, expectedHeaders) {
+  const parsed = JSON.parse(text);
+  return {
+    ok: true,
+    headers: expectedHeaders.map(String),
+    rows: toObjectRows(parsed, expectedHeaders),
+    format: 'json',
+    rendered: text,
+    diagnostics: {},
+  };
+}
+
+function normalizeUiErrorText(errorText, errorCodes = []) {
+  return {
+    ok: false,
+    errorCodes: errorCodes.filter(Boolean),
+    errorTexts: [String(errorText || '').trim()].filter(Boolean),
+    diagnostics: {},
+  };
+}
+
+module.exports = {
+  normalizeApiBody,
+  normalizeMcpPayload,
+  normalizeCliSuccess,
+  normalizeCliFailure,
+  normalizeUiGridResult,
+  normalizeUiDownloadedJson,
+  normalizeUiErrorText,
+};

--- a/tests/integration/support/schema-acceptance-fixtures.cjs
+++ b/tests/integration/support/schema-acceptance-fixtures.cjs
@@ -1,0 +1,157 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const fixturesRoot = path.join(repoRoot, 'test-fixtures', 'schema-acceptance');
+
+// Each scenario carries executable acceptance criteria so every surface
+// validates against the same contract instead of duplicating JSON metadata.
+function assertGoodDeterministicLiterals(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(true);
+  expect(normalizedResult.headers).toEqual(['First Name', 'Status']);
+  expect(normalizedResult.rows).toHaveLength(3);
+  expect(normalizedResult.rows).toEqual([
+    ['Alice', 'active'],
+    ['Alice', 'active'],
+    ['Alice', 'active'],
+  ]);
+}
+
+function assertGoodCommentsAndEnum(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(true);
+  expect(normalizedResult.headers).toEqual(['Priority', 'Status']);
+  expect(normalizedResult.rows).toHaveLength(4);
+
+  const priorityIndex = normalizedResult.headers.indexOf('Priority');
+  const statusIndex = normalizedResult.headers.indexOf('Status');
+  expect(priorityIndex).toBeGreaterThanOrEqual(0);
+  expect(statusIndex).toBeGreaterThanOrEqual(0);
+
+  for (const row of normalizedResult.rows) {
+    expect(['high', 'medium', 'low']).toContain(row[priorityIndex]);
+    expect(row[statusIndex]).toBe('active');
+  }
+}
+
+function assertGoodAutoIncrementSequence(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(true);
+  expect(normalizedResult.headers).toEqual(['Ticket']);
+  expect(normalizedResult.rows).toHaveLength(3);
+  expect(normalizedResult.rows).toEqual([['T-001.txt'], ['T-006.txt'], ['T-011.txt']]);
+}
+
+function assertGoodAutoIncrementTimestamp(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(true);
+  expect(normalizedResult.headers).toEqual(['Created At']);
+  expect(normalizedResult.rows).toHaveLength(3);
+  expect(normalizedResult.rows).toEqual([['2026-06-12'], ['2026-06-14'], ['2026-06-16']]);
+}
+
+function assertBadMissingDefinition(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(false);
+  const errorText = (normalizedResult.errorTexts || []).join(' ');
+
+  if ((normalizedResult.errorCodes || []).length > 0) {
+    expect(normalizedResult.errorCodes).toContain('missing_rule_definition');
+  }
+  expect(errorText).toContain('requires a data definition');
+}
+
+function assertBadInvalidLiteralConstraint(expect, normalizedResult) {
+  expect(normalizedResult.ok).toBe(false);
+  const errorText = (normalizedResult.errorTexts || []).join(' ');
+
+  if ((normalizedResult.errorCodes || []).length > 0) {
+    expect(normalizedResult.errorCodes).toContain('invalid_constraint_literal_value');
+  }
+  expect(errorText).toContain('constraint value');
+  expect(errorText).toContain('does not match the literal value');
+  expect(errorText).toContain('[Status]');
+}
+
+const scenarioDefinitions = [
+  {
+    // Deterministic literals let every surface prove identical success output.
+    id: 'good-deterministic-literals',
+    kind: 'good',
+    schemaFile: 'good/deterministic-literals.schema.txt',
+    rowCount: 3,
+    outputFormat: 'json',
+    expectedHeaders: ['First Name', 'Status'],
+    assertAcceptance: assertGoodDeterministicLiterals,
+  },
+  {
+    // Comments must be ignored and enum output must stay within the documented set.
+    id: 'good-comments-and-enum',
+    kind: 'good',
+    schemaFile: 'good/comments-and-enum.schema.txt',
+    rowCount: 4,
+    outputFormat: 'json',
+    expectedHeaders: ['Priority', 'Status'],
+    assertAcceptance: assertGoodCommentsAndEnum,
+  },
+  {
+    // Auto increment sequences should stay identical across all generation surfaces.
+    id: 'good-autoincrement-sequence',
+    kind: 'good',
+    schemaFile: 'good/autoincrement-sequence.schema.txt',
+    rowCount: 3,
+    outputFormat: 'json',
+    expectedHeaders: ['Ticket'],
+    assertAcceptance: assertGoodAutoIncrementSequence,
+  },
+  {
+    // Auto increment timestamps should respect explicit start, step, and formatting everywhere.
+    id: 'good-autoincrement-timestamp',
+    kind: 'good',
+    schemaFile: 'good/autoincrement-timestamp.schema.txt',
+    rowCount: 3,
+    outputFormat: 'json',
+    expectedHeaders: ['Created At'],
+    assertAcceptance: assertGoodAutoIncrementTimestamp,
+  },
+  {
+    // Missing rule definitions should fail consistently across surfaces.
+    id: 'bad-missing-definition',
+    kind: 'bad',
+    schemaFile: 'bad/missing-definition.schema.txt',
+    rowCount: 2,
+    outputFormat: 'json',
+    assertAcceptance: assertBadMissingDefinition,
+  },
+  {
+    // Contradictory literal constraints should surface a clear validation error.
+    id: 'bad-invalid-literal-constraint',
+    kind: 'bad',
+    schemaFile: 'bad/invalid-literal-constraint.schema.txt',
+    rowCount: 2,
+    outputFormat: 'json',
+    assertAcceptance: assertBadInvalidLiteralConstraint,
+  },
+];
+
+function loadScenario(entry) {
+  const schemaPath = path.join(fixturesRoot, entry.schemaFile);
+  return {
+    ...entry,
+    schemaPath,
+    schemaText: fs.readFileSync(schemaPath, 'utf8'),
+  };
+}
+
+const SCHEMA_ACCEPTANCE_SCENARIOS = scenarioDefinitions.map(loadScenario);
+
+function getSchemaAcceptanceScenario(id) {
+  const scenario = SCHEMA_ACCEPTANCE_SCENARIOS.find((entry) => entry.id === id);
+  if (!scenario) {
+    throw new Error(`Unknown schema acceptance scenario: ${id}`);
+  }
+  return scenario;
+}
+
+module.exports = {
+  repoRoot,
+  fixturesRoot,
+  SCHEMA_ACCEPTANCE_SCENARIOS,
+  getSchemaAcceptanceScenario,
+};


### PR DESCRIPTION
## What changed
- added a shared schema acceptance fixture pack with self-documenting good and bad schema files
- moved acceptance expectations into executable JavaScript scenario assertions instead of a JSON manifest
- added cross-surface acceptance coverage for CLI, MCP, API, generator UI, and embedded app test-data UI
- added explicit autoIncrement acceptance scenarios for `autoIncrement.sequence` and `autoIncrement.timestamp`

## Why
We want one shared acceptance contract that proves generation surfaces behave the same way for the same schema inputs.

## Impact
- acceptance criteria now live in code and are reused across surfaces
- good and bad schema examples are easier to extend
- autoIncrement behaviour is now covered by the shared acceptance suite

## Validation
- `pnpm run verify:local` ✅
- `pnpm test -- --runTestsByPath tests/integration/cross-surface-schema-acceptance.test.js` ✅
- `pnpm exec playwright test apps/api/src/tests/fromschema/schema-acceptance.spec.js --config=playwright-api.config.js` ✅
- `pnpm exec playwright test apps/web/src/tests/browser/generator/functional/schema-acceptance.spec.js` ✅
- `pnpm exec playwright test apps/web/src/tests/browser/app/functional/test-data/schema-acceptance.spec.js` ✅

## Notes
- an earlier local `pnpm run verify:ui` run hit an existing timeout-prone UI Jest failure outside this acceptance diff, but the final push hook completed `pnpm run verify:local` successfully.
