### PR TITLE
Fix auto defect regressions

### DIFF
--- a/apps/web/src/tests/browser/app/functional/test-data/text-schema-grid-sync.spec.js
+++ b/apps/web/src/tests/browser/app/functional/test-data/text-schema-grid-sync.spec.js
@@ -153,7 +153,7 @@ test.describe('7. Test Data Generation', () => {
     expectNoPageErrors(pageErrors);
   });
 
-  test('domain rows with invalid params show a schema error after text mode round-trip in the app editor', async ({
+  test('domain rows with invalid params switch back to schema mode with row validation in the app editor', async ({
     page,
   }) => {
     const { appPage, pageErrors } = await openApp(page);
@@ -170,10 +170,11 @@ test.describe('7. Test Data Generation', () => {
     await appPage.testDataPanel.setSchemaTextMode(true);
     await appPage.testDataPanel.schemaEditor.modeToggleButton.click();
 
+    await expect.poll(async () => appPage.testDataPanel.isRowEditorMode()).toBe(true);
+    await expect.poll(async () => appPage.testDataPanel.getSchemaErrorText()).toBe('');
     await expect
-      .poll(async () => appPage.testDataPanel.getSchemaErrorText())
-      .toContain('Name failed domain validation');
-    await expect.poll(async () => appPage.testDataPanel.isRowEditorMode()).toBe(false);
+      .poll(async () => await appPage.testDataPanel.getSchemaValidationMessage(0).textContent(), { timeout: 2500 })
+      .toContain('invalid domain params');
 
     expectNoPageErrors(pageErrors);
   });

--- a/apps/web/src/tests/browser/generator/functional/schema-edit.spec.js
+++ b/apps/web/src/tests/browser/generator/functional/schema-edit.spec.js
@@ -345,7 +345,7 @@ test.describe('Generator Schema Editing', () => {
     expectNoPageErrors(pageErrors);
   });
 
-  test('domain rows with invalid params show a schema error after text mode round-trip in the generator editor', async ({
+  test('domain rows with invalid params switch back to schema mode with row validation in the generator editor', async ({
     page,
   }) => {
     const { generatorPage, pageErrors } = await openGenerator(page);
@@ -358,8 +358,12 @@ test.describe('Generator Schema Editing', () => {
     await generatorPage.schema.setTextMode(true);
     await generatorPage.schema.modeToggleButton.click();
 
-    await expect(generatorPage.schema.errorStatus).toContainText('Name failed domain validation');
-    await expect.poll(async () => generatorPage.schema.editor.isRowEditorMode()).toBe(false);
+    await expect.poll(async () => generatorPage.schema.editor.isRowEditorMode()).toBe(true);
+    await expect(generatorPage.schema.errorStatus).toHaveText('');
+    await expect(generatorPage.schema.row(0).locator('.shared-schema-row-validation')).toContainText(
+      'invalid domain params',
+      { timeout: 2500 }
+    );
 
     expectNoPageErrors(pageErrors);
   });

--- a/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
+++ b/packages/core-ui/js/gui_components/data-grid-editor/tabulator/gridExtension-tabulator.js
@@ -744,10 +744,13 @@ class GridExtensionTabulator {
   }
 
   _setBulkData(rows) {
-    if (typeof this.tabulator.replaceData === 'function') {
-      return this.tabulator.replaceData(rows);
-    }
-    return this.tabulator.setData(rows);
+    const setResult =
+      typeof this.tabulator.replaceData === 'function'
+        ? this.tabulator.replaceData(rows)
+        : this.tabulator.setData(rows);
+    return Promise.resolve(setResult).then(() => {
+      this._reapplyActiveFiltersAfterBulkMutation();
+    });
   }
 
   async _autoFitFirstColumn() {
@@ -1067,11 +1070,25 @@ class GridExtensionTabulator {
   _refreshTableAfterBulkMutation() {
     if (typeof this.tabulator.refreshData === 'function') {
       this.tabulator.refreshData();
+      this._reapplyActiveFiltersAfterBulkMutation();
       return;
     }
 
     if (typeof this.tabulator.redraw === 'function') {
       this.tabulator.redraw(true);
+    }
+    this._reapplyActiveFiltersAfterBulkMutation();
+  }
+
+  _reapplyActiveFiltersAfterBulkMutation() {
+    if (typeof this.tabulator.refreshFilter === 'function') {
+      this.tabulator.refreshFilter();
+      return;
+    }
+
+    const activeGlobalFilter = String(this.tabUtils?.getActiveGlobalFilterQuery?.() || '').trim();
+    if (activeGlobalFilter.length > 0) {
+      this.tabUtils.filterAcrossAllColumns(activeGlobalFilter);
     }
   }
 

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
@@ -20,7 +20,7 @@ import {
 import { applySchemaCommandSelection } from './schema-row-mapper.js';
 import { schemaRowsToSpecWithTokens } from './schema-editor-core.js';
 import { schemaErrorsToText } from './schema-error-text.js';
-import { getSchemaRowSemanticValidationIssues } from './schema-row-validation.js';
+import { getSchemaRowSemanticValidationIssues, getStaticSchemaRowValidationIssues } from './schema-row-validation.js';
 import { captureActiveFieldState, restoreActiveFieldState } from './schema-focus-state.js';
 import { getDefaultDocumentObj, resolveWindowObj } from '../../dom/default-objects.js';
 import { createConfirmDialogService } from '../../dialog-services/confirm-dialog-service.js';
@@ -424,6 +424,15 @@ function createSharedSchemaEditorController({
     parsed.errors.length > 0 &&
     parsed.errors.every((error) => error?.code === 'compiler_validation_error');
 
+  const SCHEMA_UI_BLOCKING_ROW_ERROR_CODES = new Set([
+    'missing_domain_command',
+    'unknown_domain_command',
+    'helpers_not_supported_in_domain',
+    'missing_faker_command',
+    'unknown_faker_command',
+    'forbidden_faker_command',
+  ]);
+
   const getInvalidSchemaRowIndexes = (parsed) => {
     const rows = Array.isArray(parsed?.rows) ? parsed.rows : [];
     const invalidIndexes = new Set();
@@ -447,6 +456,27 @@ function createSharedSchemaEditorController({
       }
     });
     return invalidIndexes;
+  };
+
+  const canEditCompilerValidationErrorsInSchemaRows = (parsed) => {
+    if (!canRecoverSchemaDefinitionErrorsAsLiterals(parsed)) {
+      return false;
+    }
+    const invalidIndexes = getInvalidSchemaRowIndexes(parsed);
+    if (invalidIndexes.size === 0) {
+      return false;
+    }
+
+    return [...invalidIndexes].every((rowIndex) => {
+      const row = parsed.rows[rowIndex];
+      const sourceType = normaliseSourceType(row?.sourceType);
+      if (sourceType !== SOURCE_TYPE_DOMAIN && sourceType !== SOURCE_TYPE_FAKER) {
+        return false;
+      }
+      return !getStaticSchemaRowValidationIssues(row, rowIndex).some((issue) =>
+        SCHEMA_UI_BLOCKING_ROW_ERROR_CODES.has(issue?.code)
+      );
+    });
   };
 
   const convertInvalidSchemaRowsToLiterals = (parsed) => {
@@ -592,6 +622,13 @@ function createSharedSchemaEditorController({
     if (session.getTextMode()) {
       const parsed = syncFromText({ showErrors: true });
       if (parsed?.errors?.length > 0) {
+        if (canEditCompilerValidationErrorsInSchemaRows(parsed)) {
+          clearSchemaError();
+          session.setTextMode(false);
+          updateModeView();
+          applySemanticValidationForAllRows();
+          return { rows: session.getRows(), errors: parsed.errors, tokens: session.getTokens() };
+        }
         if (!canRecoverSchemaDefinitionErrorsAsLiterals(parsed)) {
           return parsed;
         }

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
@@ -433,49 +433,61 @@ function createSharedSchemaEditorController({
     'forbidden_faker_command',
   ]);
 
-  const getInvalidSchemaRowIndexes = (parsed) => {
+  const getSchemaErrorRowIndex = (parsed, error) => {
     const rows = Array.isArray(parsed?.rows) ? parsed.rows : [];
+    const column = String(error?.column ?? '').trim();
+    if (column.length > 0) {
+      const columnIndex = rows.findIndex((row) => String(row?.name ?? '').trim() === column);
+      if (columnIndex >= 0) {
+        return columnIndex;
+      }
+    }
+
+    const line = Number(error?.line);
+    if (Number.isInteger(line)) {
+      const ruleIndex = (Array.isArray(parsed?.tokens) ? parsed.tokens : [])
+        .filter((token) => token?.kind === 'rule')
+        .findIndex((token) => token?.line === line || token?.ruleLine === line || token?.headerLine === line);
+      if (ruleIndex >= 0 && ruleIndex < rows.length) {
+        return ruleIndex;
+      }
+    }
+
+    return -1;
+  };
+
+  const getInvalidSchemaRowIndexes = (parsed) => {
     const invalidIndexes = new Set();
     (Array.isArray(parsed?.errors) ? parsed.errors : []).forEach((error) => {
-      const column = String(error?.column ?? '').trim();
-      if (column.length > 0) {
-        rows.forEach((row, index) => {
-          if (String(row?.name ?? '').trim() === column) {
-            invalidIndexes.add(index);
-          }
-        });
-      }
-      const line = Number(error?.line);
-      if (Number.isInteger(line)) {
-        const ruleIndex = (Array.isArray(parsed?.tokens) ? parsed.tokens : [])
-          .filter((token) => token?.kind === 'rule')
-          .findIndex((token) => token?.line === line || token?.ruleLine === line || token?.headerLine === line);
-        if (ruleIndex >= 0 && ruleIndex < rows.length) {
-          invalidIndexes.add(ruleIndex);
-        }
+      const rowIndex = getSchemaErrorRowIndex(parsed, error);
+      if (rowIndex >= 0) {
+        invalidIndexes.add(rowIndex);
       }
     });
     return invalidIndexes;
+  };
+
+  const isSchemaRowEditableForCompilerValidationError = (row, rowIndex) => {
+    const sourceType = normaliseSourceType(row?.sourceType);
+    if (sourceType !== SOURCE_TYPE_DOMAIN && sourceType !== SOURCE_TYPE_FAKER) {
+      return false;
+    }
+    return !getStaticSchemaRowValidationIssues(row, rowIndex).some((issue) =>
+      SCHEMA_UI_BLOCKING_ROW_ERROR_CODES.has(issue?.code)
+    );
   };
 
   const canEditCompilerValidationErrorsInSchemaRows = (parsed) => {
     if (!canRecoverSchemaDefinitionErrorsAsLiterals(parsed)) {
       return false;
     }
-    const invalidIndexes = getInvalidSchemaRowIndexes(parsed);
-    if (invalidIndexes.size === 0) {
-      return false;
-    }
 
-    return [...invalidIndexes].every((rowIndex) => {
-      const row = parsed.rows[rowIndex];
-      const sourceType = normaliseSourceType(row?.sourceType);
-      if (sourceType !== SOURCE_TYPE_DOMAIN && sourceType !== SOURCE_TYPE_FAKER) {
+    return parsed.errors.every((error) => {
+      const rowIndex = getSchemaErrorRowIndex(parsed, error);
+      if (rowIndex < 0) {
         return false;
       }
-      return !getStaticSchemaRowValidationIssues(row, rowIndex).some((issue) =>
-        SCHEMA_UI_BLOCKING_ROW_ERROR_CODES.has(issue?.code)
-      );
+      return isSchemaRowEditableForCompilerValidationError(parsed.rows[rowIndex], rowIndex);
     });
   };
 

--- a/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
+++ b/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
@@ -46,6 +46,16 @@ function createTabulatorStub() {
   };
 }
 
+function createGenericDataTable({ headers, rows }) {
+  return {
+    getColumnCount: () => headers.length,
+    getHeaders: () => headers,
+    getRowCount: () => rows.length,
+    getRowAsObjectUsingHeadings: (rowIndex, fieldNames) =>
+      Object.fromEntries(fieldNames.map((fieldName, index) => [fieldName, rows[rowIndex][index]])),
+  };
+}
+
 describe('GridExtensionTabulator duplicate column', () => {
   test('tabulator helper returns the underlying addData result for row insertion helpers', () => {
     const addDataResult = Promise.resolve('row-added');
@@ -174,5 +184,59 @@ describe('GridExtensionTabulator duplicate column', () => {
     await addRowPromise;
 
     expect(gridChanged).toHaveBeenCalledTimes(1);
+  });
+
+  test('setGridFromGenericDataTable refreshes active filters after replacing data', async () => {
+    const tabulator = createTabulatorStub();
+    tabulator.setColumns = jest.fn((columns) => {
+      tabulator._columnDefinitions = columns;
+    });
+    tabulator.setData = jest.fn((rows) => {
+      tabulator._rowData = rows;
+    });
+    tabulator.refreshFilter = jest.fn();
+    tabulator.getColumn = jest.fn(() => createColumnComponent(tabulator._columnDefinitions[0]));
+    const extension = new GridExtensionTabulator(tabulator);
+
+    await extension.setGridFromGenericDataTable(
+      createGenericDataTable({
+        headers: ['CaseId'],
+        rows: [['100'], ['200']],
+      })
+    );
+
+    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(1);
+  });
+
+  test('applyGeneratedSchemaAmend refreshes active filters after mutating visible rows', async () => {
+    const tabulator = createTabulatorStub();
+    tabulator._columnDefinitions = [{ title: 'CaseId', field: 'column1' }];
+    tabulator._rowData = [{ column1: '2' }];
+    tabulator.getData = jest.fn((mode) => {
+      if (mode === 'active') {
+        return tabulator._rowData;
+      }
+      return tabulator._rowData;
+    });
+    tabulator.getDataCount = jest.fn((mode) => {
+      if (mode === 'active') {
+        return tabulator._rowData.length;
+      }
+      return tabulator._rowData.length;
+    });
+    tabulator.refreshData = jest.fn();
+    tabulator.refreshFilter = jest.fn();
+    const extension = new GridExtensionTabulator(tabulator);
+
+    await extension.applyGeneratedSchemaAmend({
+      mode: 'amend-table',
+      desiredRowCount: 1,
+      schemaHeaders: ['CaseId'],
+      generateRow: () => ['100'],
+    });
+
+    expect(tabulator._rowData).toEqual([{ column1: '100' }]);
+    expect(tabulator.refreshData).toHaveBeenCalledTimes(1);
+    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
+++ b/packages/core-ui/src/tests/grid/tabulator-duplicate-column-copy.test.js
@@ -56,6 +56,37 @@ function createGenericDataTable({ headers, rows }) {
   };
 }
 
+function addFilterSupport(tabulator) {
+  tabulator._filterPredicate = null;
+  tabulator._activeRows = tabulator._rowData;
+  tabulator.setFilter = jest.fn((predicate) => {
+    tabulator._filterPredicate = predicate;
+    tabulator.refreshFilter();
+  });
+  tabulator.clearFilter = jest.fn(() => {
+    tabulator._filterPredicate = null;
+    tabulator._activeRows = tabulator._rowData;
+  });
+  tabulator.refreshFilter = jest.fn(() => {
+    tabulator._activeRows =
+      typeof tabulator._filterPredicate === 'function'
+        ? tabulator._rowData.filter((row) => tabulator._filterPredicate(row))
+        : tabulator._rowData;
+  });
+  tabulator.getData = jest.fn((mode) => {
+    if (mode === 'active') {
+      return tabulator._activeRows;
+    }
+    return tabulator._rowData.map((row) => ({ ...row }));
+  });
+  tabulator.getDataCount = jest.fn((mode) => {
+    if (mode === 'active') {
+      return tabulator._activeRows.length;
+    }
+    return tabulator._rowData.length;
+  });
+}
+
 describe('GridExtensionTabulator duplicate column', () => {
   test('tabulator helper returns the underlying addData result for row insertion helpers', () => {
     const addDataResult = Promise.resolve('row-added');
@@ -194,9 +225,12 @@ describe('GridExtensionTabulator duplicate column', () => {
     tabulator.setData = jest.fn((rows) => {
       tabulator._rowData = rows;
     });
-    tabulator.refreshFilter = jest.fn();
+    addFilterSupport(tabulator);
     tabulator.getColumn = jest.fn(() => createColumnComponent(tabulator._columnDefinitions[0]));
     const extension = new GridExtensionTabulator(tabulator);
+
+    extension.filterText('200');
+    expect(tabulator.getData('active')).toEqual([]);
 
     await extension.setGridFromGenericDataTable(
       createGenericDataTable({
@@ -205,28 +239,20 @@ describe('GridExtensionTabulator duplicate column', () => {
       })
     );
 
-    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(1);
+    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(2);
+    expect(tabulator.getData('active')).toEqual([{ column1: '200' }]);
   });
 
   test('applyGeneratedSchemaAmend refreshes active filters after mutating visible rows', async () => {
     const tabulator = createTabulatorStub();
     tabulator._columnDefinitions = [{ title: 'CaseId', field: 'column1' }];
-    tabulator._rowData = [{ column1: '2' }];
-    tabulator.getData = jest.fn((mode) => {
-      if (mode === 'active') {
-        return tabulator._rowData;
-      }
-      return tabulator._rowData;
-    });
-    tabulator.getDataCount = jest.fn((mode) => {
-      if (mode === 'active') {
-        return tabulator._rowData.length;
-      }
-      return tabulator._rowData.length;
-    });
+    tabulator._rowData = [{ column1: '2' }, { column1: '3' }];
     tabulator.refreshData = jest.fn();
-    tabulator.refreshFilter = jest.fn();
+    addFilterSupport(tabulator);
     const extension = new GridExtensionTabulator(tabulator);
+
+    extension.filterText('2');
+    expect(tabulator.getData('active')).toEqual([{ column1: '2' }]);
 
     await extension.applyGeneratedSchemaAmend({
       mode: 'amend-table',
@@ -235,8 +261,9 @@ describe('GridExtensionTabulator duplicate column', () => {
       generateRow: () => ['100'],
     });
 
-    expect(tabulator._rowData).toEqual([{ column1: '100' }]);
+    expect(tabulator._rowData).toEqual([{ column1: '100' }, { column1: '3' }]);
+    expect(tabulator.getData('active')).toEqual([]);
     expect(tabulator.refreshData).toHaveBeenCalledTimes(1);
-    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(1);
+    expect(tabulator.refreshFilter).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
+++ b/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
@@ -625,6 +625,68 @@ describe('createSharedSchemaEditorController', () => {
     expect(root.querySelector('[data-role="schema-error"]')?.textContent || '').toBe('');
   });
 
+  test('keeps text mode when compiler validation includes an unmatched error', async () => {
+    const root = createRoot(dom.window.document);
+    const requestConfirm = jest.fn(() => Promise.resolve(false));
+    const onSchemaError = jest.fn();
+    const schemaTextToDataRules = jest.fn(() => ({
+      dataRules: [{ name: 'Num', ruleSpec: 'number.int(min=1, min=2)', type: 'domain' }],
+      errors: [
+        {
+          code: 'compiler_validation_error',
+          column: 'Num',
+          message: 'Num failed domain validation - Invalid keyword arguments: duplicate named argument "min"',
+        },
+        {
+          code: 'compiler_validation_error',
+          message: 'Constraint validation failed without a row anchor',
+        },
+      ],
+      schemaTokens: [{ kind: 'rule', name: 'Num', rule: 'number.int(min=1, min=2)', ruleLine: 2 }],
+      constraints: [],
+    }));
+    const controller = createSharedSchemaEditorController({
+      documentObj: dom.window.document,
+      rootElement: root,
+      requestConfirm,
+      createBlankRow: () => ({
+        id: 'blank',
+        name: '',
+        sourceType: 'domain',
+        command: '',
+        value: '',
+        params: '',
+        semanticValidationIssues: [],
+      }),
+      mapRuleToRow: (rule) => ({
+        id: rule.name,
+        name: rule.name,
+        sourceType: rule.type,
+        command: 'number.int',
+        value: '',
+        params: '(min=1, min=2)',
+        semanticValidationIssues: [],
+      }),
+      schemaTextToDataRules,
+      dataRulesToSchemaText,
+      onSchemaError,
+      validateSchemaRows: jest.fn((rows) => ({ rows, errors: [] })),
+      updatePairwiseButtonVisibility: jest.fn(),
+      updateHelpHints: jest.fn(),
+    });
+
+    controller.init();
+    controller.setTextMode(true);
+    root.querySelector('[data-role="schema-textbox"]').value = 'Num\nnumber.int(min=1, min=2)';
+
+    const result = await controller.toggleMode();
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(result.errors).toHaveLength(2);
+    expect(controller.getState().isTextMode).toBe(true);
+    expect(onSchemaError).toHaveBeenLastCalledWith(expect.stringContaining('Constraint validation failed'));
+  });
+
   test('stays in text mode when invalid text definition literal conversion is declined', async () => {
     const root = createRoot(dom.window.document);
     const requestConfirm = jest.fn(() => Promise.resolve(false));

--- a/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
+++ b/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
@@ -1,7 +1,9 @@
 import { jest } from '@jest/globals';
 import { JSDOM } from 'jsdom';
 import { fireEvent, within } from '@testing-library/dom';
-import { dataRulesToSchemaText } from '@anywaydata/core/data_generation/schema-rules-adapter.js';
+import { faker } from '@faker-js/faker';
+import RandExp from 'randexp';
+import { dataRulesToSchemaText, schemaTextToDataRules } from '@anywaydata/core/data_generation/schema-rules-adapter.js';
 import * as schemaControllerExports from '../../../js/gui_components/shared/test-data/schema/schema-controller.js';
 import * as schemaEditorCoreExports from '../../../js/gui_components/shared/test-data/schema/schema-editor-core.js';
 import { createSharedSchemaEditorController } from '../../../js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js';
@@ -548,6 +550,76 @@ describe('createSharedSchemaEditorController', () => {
         sourceType: 'literal',
         command: 'literal',
         value: 'person.notACommand()',
+      }),
+    ]);
+    expect(root.querySelector('[data-role="schema-error"]')?.textContent || '').toBe('');
+  });
+
+  test('switches from text to schema rows without literal conversion when a known command has invalid params', async () => {
+    const root = createRoot(dom.window.document);
+    const requestConfirm = jest.fn(() => Promise.resolve(true));
+    const controller = createSharedSchemaEditorController({
+      documentObj: dom.window.document,
+      rootElement: root,
+      requestConfirm,
+      faker,
+      RandExp,
+      createBlankRow: () => ({
+        id: 'blank',
+        name: '',
+        sourceType: 'domain',
+        command: '',
+        value: '',
+        params: '',
+        semanticValidationIssues: [],
+      }),
+      mapRuleToRow: (rule) => {
+        const ruleSpec = String(rule?.ruleSpec ?? '');
+        const openParenIndex = ruleSpec.indexOf('(');
+        return {
+          id: rule.name,
+          name: rule.name,
+          sourceType: rule.type,
+          command: openParenIndex > 0 ? ruleSpec.slice(0, openParenIndex) : ruleSpec,
+          value: '',
+          params: openParenIndex > 0 ? ruleSpec.slice(openParenIndex) : '',
+          semanticValidationIssues: [],
+        };
+      },
+      schemaTextToDataRules,
+      dataRulesToSchemaText,
+      validateSchemaRows: jest.fn((rows) => ({ rows, errors: [] })),
+      updatePairwiseButtonVisibility: jest.fn(),
+      updateHelpHints: jest.fn(),
+    });
+
+    controller.init();
+    controller.setTextMode(true);
+    root.querySelector('[data-role="schema-textbox"]').value = 'Num\nnumber.int(min=1, min=2, max=3)';
+
+    const result = await controller.toggleMode();
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        code: 'compiler_validation_error',
+        column: 'Num',
+        message: expect.stringContaining('duplicate named argument "min"'),
+      }),
+    ]);
+    expect(controller.getState().isTextMode).toBe(false);
+    expect(controller.getState().rows).toEqual([
+      expect.objectContaining({
+        name: 'Num',
+        sourceType: 'domain',
+        command: 'number.int',
+        params: '(min=1, min=2, max=3)',
+        semanticValidationIssues: [
+          expect.objectContaining({
+            field: 'params',
+            message: expect.stringContaining('duplicate named argument "min"'),
+          }),
+        ],
       }),
     ]);
     expect(root.querySelector('[data-role="schema-error"]')?.textContent || '').toBe('');

--- a/packages/core/js/keywords/domain/autoincrement/sequence-keyword-definition.js
+++ b/packages/core/js/keywords/domain/autoincrement/sequence-keyword-definition.js
@@ -1,5 +1,25 @@
 import { validateStringOrNumberValue } from '../../../command-help/command-help-validators.js';
 
+function validateAutoIncrementSequenceArgs(_args = [], context = {}) {
+  const argsByName = context?.argsByName || {};
+
+  if (Object.is(argsByName.step, 0)) {
+    return {
+      ok: false,
+      error: 'Invalid keyword arguments: argument "step" must be a non-zero integer',
+    };
+  }
+
+  if (typeof argsByName.zeropadding !== 'undefined' && argsByName.zeropadding < 0) {
+    return {
+      ok: false,
+      error: 'Invalid keyword arguments: argument "zeropadding" must be greater than or equal to 0',
+    };
+  }
+
+  return { ok: true };
+}
+
 const AUTO_INCREMENT_SEQUENCE_KEYWORD_DEFINITION = {
   keyword: 'autoIncrement.sequence',
   delegate: {
@@ -12,6 +32,7 @@ const AUTO_INCREMENT_SEQUENCE_KEYWORD_DEFINITION = {
     docsUrl: 'https://anywaydata.com/docs/test-data/auto-increment-sequences',
     fakerDocsUrl: '',
     validator: validateStringOrNumberValue,
+    argsValidator: validateAutoIncrementSequenceArgs,
     returnType: 'string|number',
     usageExamples: [
       {

--- a/packages/core/js/keywords/domain/autoincrement/sequence-keyword-definition.js
+++ b/packages/core/js/keywords/domain/autoincrement/sequence-keyword-definition.js
@@ -3,7 +3,7 @@ import { validateStringOrNumberValue } from '../../../command-help/command-help-
 function validateAutoIncrementSequenceArgs(_args = [], context = {}) {
   const argsByName = context?.argsByName || {};
 
-  if (Object.is(argsByName.step, 0)) {
+  if (argsByName.step === 0) {
     return {
       ok: false,
       error: 'Invalid keyword arguments: argument "step" must be a non-zero integer',

--- a/packages/core/src/tests/core-api/generateFromTextSpec.test.js
+++ b/packages/core/src/tests/core-api/generateFromTextSpec.test.js
@@ -438,6 +438,16 @@ test.each([
     message: 'argument "multipleOf" must be greater than 0',
   },
   {
+    label: 'autoIncrement.sequence step zero',
+    textSpec: 'Sequence\nautoIncrement.sequence(start=1,step=0)',
+    message: 'argument "step" must be a non-zero integer',
+  },
+  {
+    label: 'autoIncrement.sequence negative zeropadding',
+    textSpec: 'Sequence\nautoIncrement.sequence(start=1,step=1,zeropadding=-1)',
+    message: 'argument "zeropadding" must be greater than or equal to 0',
+  },
+  {
     label: 'date.recent negative days',
     textSpec: 'Date\ndate.recent(days=-7)',
     message: 'argument "days" must be greater than or equal to 0',

--- a/packages/core/src/tests/data_generation/keywords/domain/autoincrement/sequence-exec.test.js
+++ b/packages/core/src/tests/data_generation/keywords/domain/autoincrement/sequence-exec.test.js
@@ -29,6 +29,6 @@ describe('autoIncrement.sequence domain keyword execution', () => {
   test('surfaces helper validation errors through the domain keyword interface', () => {
     expect(() =>
       executeDomainKeyword('autoIncrement.sequence', { faker, args: [1, 0], autoIncrementState: {} })
-    ).toThrow('Invalid argument for step: expected a non-zero integer.');
+    ).toThrow('Invalid keyword arguments: argument "step" must be a non-zero integer');
   });
 });

--- a/packages/core/src/tests/data_generation/unit/domain/domainKeywords.test.js
+++ b/packages/core/src/tests/data_generation/unit/domain/domainKeywords.test.js
@@ -488,6 +488,10 @@ describe('domain keyword arg validation', () => {
       ok: false,
       error: 'Invalid keyword arguments: argument "step" must be a non-zero integer',
     });
+    expect(validateDomainKeywordArgs(keyword, [1, -0])).toEqual({
+      ok: false,
+      error: 'Invalid keyword arguments: argument "step" must be a non-zero integer',
+    });
     expect(validateDomainKeywordArgs(keyword, [1, 1, '', '', -1])).toEqual({
       ok: false,
       error: 'Invalid keyword arguments: argument "zeropadding" must be greater than or equal to 0',

--- a/packages/core/src/tests/data_generation/unit/domain/domainKeywords.test.js
+++ b/packages/core/src/tests/data_generation/unit/domain/domainKeywords.test.js
@@ -481,6 +481,19 @@ describe('domain keyword arg validation', () => {
     });
   });
 
+  test('rejects invalid autoIncrement.sequence parameters before generation', () => {
+    const keyword = getDomainKeywordByAlias('autoIncrement.sequence');
+
+    expect(validateDomainKeywordArgs(keyword, [1, 0])).toEqual({
+      ok: false,
+      error: 'Invalid keyword arguments: argument "step" must be a non-zero integer',
+    });
+    expect(validateDomainKeywordArgs(keyword, [1, 1, '', '', -1])).toEqual({
+      ok: false,
+      error: 'Invalid keyword arguments: argument "zeropadding" must be greater than or equal to 0',
+    });
+  });
+
   test('rejects datatype.boolean probability outside documented range', () => {
     const keyword = getDomainKeywordByAlias('datatype.boolean');
 


### PR DESCRIPTION
## Summary

Fixes the auto defect batch by tightening invalid schema argument handling, preserving active grid filters after generated-data amendments, and allowing known commands with invalid params to move from text schema back into Schema UI with row-level validation.

## Changes

- Validate `autoIncrement.sequence` so `step=0` and negative `zeropadding` fail at schema validation instead of producing `ERROR` rows.
- Reapply active global filters after bulk/generated data mutations in the Tabulator grid adapter.
- Distinguish unknown or malformed schema commands from known commands with invalid params during text-to-schema switching.
- Update controller, Jest, and browser coverage for the fixed paths.

## Validation

- `pnpm run verify:ui`
- `pnpm run verify:local`

Closes #253
Closes #268
Closes #269
Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema/grid editor behavior for invalid domain parameters: the UI keeps the row editor active, clears the general error banner, and displays per-row validation messaging (including after text-mode round-trips).
  * Preserved active filters after bulk data updates and generated schema changes, ensuring filtered results remain consistent.
  * Tightened `autoIncrement.sequence` argument validation by rejecting `step = 0` and negative `zeropadding`, with clearer compiler-style error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->