### PR TITLE
Add unsafe faker browser setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ experiments
 experiments/*
 .codex-logs/
 .codex-dev-web.log
+.codex-dev-web-*.stdout.log
+.codex-dev-web-*.stderr.log

--- a/apps/api/src/openapi.js
+++ b/apps/api/src/openapi.js
@@ -100,7 +100,8 @@ const openApiDocument = {
                   unsafeFakerExpressions: {
                     type: 'boolean',
                     default: false,
-                    description: 'Allow expression-style faker arguments (unsafe for untrusted input)',
+                    description:
+                      'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
                   },
                   responseFormat: { type: 'string', enum: ['rows', 'rendered', 'all', 'raw'], default: 'rows' },
                 },
@@ -168,7 +169,8 @@ const openApiDocument = {
                   unsafeFakerExpressions: {
                     type: 'boolean',
                     default: false,
-                    description: 'Allow expression-style faker arguments (unsafe for untrusted input)',
+                    description:
+                      'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
                   },
                   responseFormat: { type: 'string', enum: ['rows', 'rendered', 'all', 'raw'], default: 'rows' },
                 },
@@ -317,7 +319,8 @@ const openApiDocument = {
               type: 'boolean',
               default: false,
             },
-            description: 'Allow expression-style faker arguments (unsafe for untrusted input)',
+            description:
+              'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
           },
           {
             in: 'query',
@@ -428,7 +431,12 @@ const openApiDocument = {
                     description:
                       'Comma-separated imported field names whose values should be trimmed before amend processing.',
                   },
-                  unsafeFakerExpressions: { type: 'boolean', default: false },
+                  unsafeFakerExpressions: {
+                    type: 'boolean',
+                    default: false,
+                    description:
+                      'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
+                  },
                   responseFormat: { type: 'string', enum: ['rows', 'rendered', 'all', 'raw'], default: 'rows' },
                   stream: { type: 'boolean', description: 'Accepted for compatibility and ignored for amend mode.' },
                 },

--- a/apps/mcp/src/mcp.test.js
+++ b/apps/mcp/src/mcp.test.js
@@ -233,6 +233,27 @@ test('MCP server rejects unsafe faker expression arguments', () => {
   expect(payload.error.message).toMatch(/Unsafe faker rule syntax detected/);
 });
 
+test('MCP server opts in to unsafe faker expression arguments', () => {
+  const response = requestServer({
+    jsonrpc: '2.0',
+    id: 4.5,
+    method: 'tools/call',
+    params: {
+      name: 'generate_data_from_spec',
+      arguments: {
+        textSpec: 'Sentence\nhelpers.mustache("Hello {{name}}", { name: () => "Ada" })',
+        rowCount: 1,
+        outputFormat: 'json',
+        unsafeFakerExpressions: true,
+      },
+    },
+  });
+  const payload = JSON.parse(response?.result?.content?.[0]?.text || '{}');
+  expect(response?.result?.isError).toBe(false);
+  expect(payload.ok).toBe(true);
+  expect(payload.rows).toEqual([['Hello Ada']]);
+});
+
 test('MCP server returns discoverable options schema for xml output format', () => {
   const response = requestServer({
     jsonrpc: '2.0',

--- a/apps/web/src/stories/population-actions.stories.js
+++ b/apps/web/src/stories/population-actions.stories.js
@@ -30,6 +30,8 @@ function renderPopulationActionsStory(args) {
       generateHelpHtml: args.generateHelpHtml,
       generatePairwiseHelpHtml: args.generatePairwiseHelpHtml,
       generateSchemaHelpHtml: '<p>Scan the current grid and build an enum-only schema from visible values.</p>',
+      unsafeFakerExpressionsVisible: args.unsafeFakerExpressionsVisible,
+      unsafeFakerExpressions: args.unsafeFakerExpressions,
     },
     callbacks: {
       onGenerate: () => {
@@ -43,6 +45,10 @@ function renderPopulationActionsStory(args) {
       onGenerateSchemaFromGrid: () => {
         args.onGenerateSchemaFromGrid?.();
         result.textContent = 'action:generate-schema';
+      },
+      onUnsafeFakerExpressionsChange: (isEnabled) => {
+        args.onUnsafeFakerExpressionsChange?.(isEnabled);
+        result.textContent = `risky-faker:${isEnabled}`;
       },
     },
   });
@@ -69,7 +75,7 @@ const meta = {
         ),
       description: {
         component:
-          'PopulationActions is the reusable action cluster shared by the app test-data panel and the generator controls. It owns the Generate action plus an optional secondary combination action, with host-configured labels and help tippies for each action.',
+          'PopulationActions is the reusable action cluster shared by the app test-data panel and the generator controls. It owns the Generate action, the app-side risky Faker generation setting when enabled by the host, and an optional secondary combination action, with host-configured labels and help tippies for each action.',
       },
     },
   },
@@ -83,9 +89,12 @@ const meta = {
       '<p>Generate data from the current schema directly into the grid.</p><p><a class="helplink" href="/docs/test-data/test-data-generation" target="anywaydatadocs">Test-data generation docs</a></p>',
     generatePairwiseHelpHtml:
       '<p>Generate n-wise combinations from enum columns in the current schema directly into the grid.</p><p><a class="helplink" href="/docs/test-data/n-wise-testing" target="_blank" rel="noopener noreferrer">N-wise generation docs</a></p>',
+    unsafeFakerExpressionsVisible: true,
+    unsafeFakerExpressions: true,
     onGenerate: fn(),
     onGeneratePairwise: fn(),
     onGenerateSchemaFromGrid: fn(),
+    onUnsafeFakerExpressionsChange: fn(),
   },
   argTypes: {
     pairwiseVisible: {
@@ -116,6 +125,14 @@ const meta = {
       control: 'text',
       description: 'Raw HTML used as the secondary action help tippy content, including links.',
     },
+    unsafeFakerExpressionsVisible: {
+      control: 'boolean',
+      description: 'Shows the app-side generation settings cog before the Generate help tippy.',
+    },
+    unsafeFakerExpressions: {
+      control: 'boolean',
+      description: 'Whether browser generation allows expression-style Faker helper arguments.',
+    },
     onGenerate: {
       description: 'Storybook action fired when the primary Generate button is clicked.',
       table: { category: 'Events' },
@@ -126,6 +143,10 @@ const meta = {
     },
     onGenerateSchemaFromGrid: {
       description: 'Storybook action fired when the Grid to Enum Schema button is clicked.',
+      table: { category: 'Events' },
+    },
+    onUnsafeFakerExpressionsChange: {
+      description: 'Storybook action fired when the risky Faker setting changes.',
       table: { category: 'Events' },
     },
   },
@@ -140,7 +161,7 @@ export const Default = {
     docs: {
       description: {
         story:
-          'Shows the default app-style action cluster with the generator-style icon button and a host-configured help tippy that talks about generating into the grid. Click **Generate** and confirm the story log updates.',
+          'Shows the default app-style action cluster with the generation settings cog beside Generate and a host-configured help tippy that talks about generating into the grid. Open settings, uncheck allow risky faker, and confirm the setting event; click **Generate** to confirm the main action still fires.',
       },
     },
   },
@@ -149,7 +170,13 @@ export const Default = {
     await expect(canvas.getByRole('button', { name: 'Generate', exact: true })).toBeEnabled();
     await expect(canvas.queryByRole('button', { name: 'Generate Combinations' })).toBeNull();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Generation settings' })).toHaveAttribute('aria-expanded', 'false');
     await expect(canvas.getAllByRole('button', { name: /show .* help/i })).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
+    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
+    await expect(canvas.getByRole('button', { name: 'Show risky Faker help' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('checkbox', { name: 'allow risky faker' }));
+    await expect(canvas.getByText('risky-faker:false')).toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate', exact: true }));
     await expect(canvas.getByText('action:generate')).toBeVisible();
   },
@@ -174,6 +201,8 @@ export const PairwiseAvailable = {
     await expect(canvas.getByRole('button', { name: 'Generate Combinations' })).toBeEnabled();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeVisible();
     await expect(canvas.getAllByRole('button', { name: /show .* help/i })).toHaveLength(3);
+    await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
+    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate Combinations' }));
     await expect(canvas.getByText('action:generate-secondary')).toBeVisible();
   },
@@ -199,6 +228,8 @@ export const BusyStates = {
     await expect(canvas.getByRole('button', { name: 'Generate', exact: true })).toBeDisabled();
     await expect(canvas.getByRole('button', { name: 'Generate Combinations' })).toBeDisabled();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeEnabled();
+    await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
+    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
     await expect(canvas.getByRole('button', { name: 'Generate', exact: true })).toHaveAttribute(
       'aria-disabled',
       'true'

--- a/apps/web/src/stories/population-actions.stories.js
+++ b/apps/web/src/stories/population-actions.stories.js
@@ -48,7 +48,7 @@ function renderPopulationActionsStory(args) {
       },
       onUnsafeFakerExpressionsChange: (isEnabled) => {
         args.onUnsafeFakerExpressionsChange?.(isEnabled);
-        result.textContent = `risky-faker:${isEnabled}`;
+        result.textContent = `unsafe-faker:${isEnabled}`;
       },
     },
   });
@@ -75,7 +75,7 @@ const meta = {
         ),
       description: {
         component:
-          'PopulationActions is the reusable action cluster shared by the app test-data panel and the generator controls. It owns the Generate action, the app-side risky Faker generation setting when enabled by the host, and an optional secondary combination action, with host-configured labels and help tippies for each action.',
+          'PopulationActions is the reusable action cluster shared by the app test-data panel and the generator controls. It owns the Generate action, the app-side unsafe Faker generation setting when enabled by the host, and an optional secondary combination action, with host-configured labels and help tippies for each action.',
       },
     },
   },
@@ -90,7 +90,7 @@ const meta = {
     generatePairwiseHelpHtml:
       '<p>Generate n-wise combinations from enum columns in the current schema directly into the grid.</p><p><a class="helplink" href="/docs/test-data/n-wise-testing" target="_blank" rel="noopener noreferrer">N-wise generation docs</a></p>',
     unsafeFakerExpressionsVisible: true,
-    unsafeFakerExpressions: true,
+    unsafeFakerExpressions: false,
     onGenerate: fn(),
     onGeneratePairwise: fn(),
     onGenerateSchemaFromGrid: fn(),
@@ -146,7 +146,7 @@ const meta = {
       table: { category: 'Events' },
     },
     onUnsafeFakerExpressionsChange: {
-      description: 'Storybook action fired when the risky Faker setting changes.',
+      description: 'Storybook action fired when the unsafe Faker setting changes.',
       table: { category: 'Events' },
     },
   },
@@ -161,7 +161,7 @@ export const Default = {
     docs: {
       description: {
         story:
-          'Shows the default app-style action cluster with the generation settings cog beside Generate and a host-configured help tippy that talks about generating into the grid. Open settings, uncheck allow risky faker, and confirm the setting event; click **Generate** to confirm the main action still fires.',
+          'Shows the default app-style action cluster with the generation settings cog beside Generate and a host-configured help tippy that talks about generating into the grid. Open settings, enable allow unsafe faker, and confirm the setting event; click **Generate** to confirm the main action still fires.',
       },
     },
   },
@@ -173,10 +173,10 @@ export const Default = {
     await expect(canvas.getByRole('button', { name: 'Generation settings' })).toHaveAttribute('aria-expanded', 'false');
     await expect(canvas.getAllByRole('button', { name: /show .* help/i })).toHaveLength(2);
     await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
-    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
-    await expect(canvas.getByRole('button', { name: 'Show risky Faker help' })).toBeVisible();
-    await userEvent.click(canvas.getByRole('checkbox', { name: 'allow risky faker' }));
-    await expect(canvas.getByText('risky-faker:false')).toBeVisible();
+    await expect(canvas.getByRole('checkbox', { name: 'allow unsafe faker' })).not.toBeChecked();
+    await expect(canvas.getByRole('button', { name: 'Show unsafe Faker help' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('checkbox', { name: 'allow unsafe faker' }));
+    await expect(canvas.getByText('unsafe-faker:true')).toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate', exact: true }));
     await expect(canvas.getByText('action:generate')).toBeVisible();
   },
@@ -202,7 +202,7 @@ export const PairwiseAvailable = {
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeVisible();
     await expect(canvas.getAllByRole('button', { name: /show .* help/i })).toHaveLength(3);
     await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
-    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
+    await expect(canvas.getByRole('checkbox', { name: 'allow unsafe faker' })).not.toBeChecked();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate Combinations' }));
     await expect(canvas.getByText('action:generate-secondary')).toBeVisible();
   },
@@ -229,7 +229,7 @@ export const BusyStates = {
     await expect(canvas.getByRole('button', { name: 'Generate Combinations' })).toBeDisabled();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeEnabled();
     await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
-    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
+    await expect(canvas.getByRole('checkbox', { name: 'allow unsafe faker' })).not.toBeChecked();
     await expect(canvas.getByRole('button', { name: 'Generate', exact: true })).toHaveAttribute(
       'aria-disabled',
       'true'

--- a/apps/web/src/stories/test-data-embedded-panel.stories.js
+++ b/apps/web/src/stories/test-data-embedded-panel.stories.js
@@ -124,6 +124,7 @@ function renderDataPopulationPanelStory(args) {
         normalizeOnInput: true,
       },
       schemaDefinitionProps: createSchemaDefinitionProps(schemaTextSyncState),
+      unsafeFakerExpressions: args.unsafeFakerExpressions,
     },
     callbacks: {
       onGenerate: () => {
@@ -178,6 +179,7 @@ const meta = {
     selectedMode: 'new-table',
     pairwiseVisible: false,
     rowCount: 1,
+    unsafeFakerExpressions: true,
     schemaRows: [],
     textMode: false,
   },
@@ -194,6 +196,10 @@ const meta = {
     rowCount: {
       control: 'number',
       description: 'Initial count shown in the shared row-count control.',
+    },
+    unsafeFakerExpressions: {
+      control: 'boolean',
+      description: 'Initial browser generation setting for expression-style Faker helper arguments.',
     },
     schemaRows: {
       control: false,
@@ -214,13 +220,15 @@ export const NewTableMode = {
     docs: {
       description: {
         story:
-          'Shows the embedded panel in its default new-table mode. Review the shared row-count control, schema editor, and primary Generate action without combinations generation enabled. Try Generate to confirm the composed panel callback fires through the interaction log.',
+          'Shows the embedded panel in its default new-table mode. Review the generation settings cog, shared row-count control, schema editor, and primary Generate action without combinations generation enabled. Open settings to inspect allow risky faker, then try Generate to confirm the composed panel callback fires through the interaction log.',
       },
     },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button', { name: 'Generate' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
+    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
     await expect(canvas.getByLabelText('How Many?')).toHaveValue(1);
     await expect(canvas.getByRole('radio', { name: 'New Table' })).toBeChecked();
     await expect(canvas.queryByRole('button', { name: 'Generate Combinations' })).toBeNull();

--- a/apps/web/src/stories/test-data-embedded-panel.stories.js
+++ b/apps/web/src/stories/test-data-embedded-panel.stories.js
@@ -179,7 +179,7 @@ const meta = {
     selectedMode: 'new-table',
     pairwiseVisible: false,
     rowCount: 1,
-    unsafeFakerExpressions: true,
+    unsafeFakerExpressions: false,
     schemaRows: [],
     textMode: false,
   },
@@ -220,7 +220,7 @@ export const NewTableMode = {
     docs: {
       description: {
         story:
-          'Shows the embedded panel in its default new-table mode. Review the generation settings cog, shared row-count control, schema editor, and primary Generate action without combinations generation enabled. Open settings to inspect allow risky faker, then try Generate to confirm the composed panel callback fires through the interaction log.',
+          'Shows the embedded panel in its default new-table mode. Review the generation settings cog, shared row-count control, schema editor, and primary Generate action without combinations generation enabled. Open settings to inspect allow unsafe faker, then try Generate to confirm the composed panel callback fires through the interaction log.',
       },
     },
   },
@@ -228,7 +228,7 @@ export const NewTableMode = {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button', { name: 'Generate' })).toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
-    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
+    await expect(canvas.getByRole('checkbox', { name: 'allow unsafe faker' })).not.toBeChecked();
     await expect(canvas.getByLabelText('How Many?')).toHaveValue(1);
     await expect(canvas.getByRole('radio', { name: 'New Table' })).toBeChecked();
     await expect(canvas.queryByRole('button', { name: 'Generate Combinations' })).toBeNull();

--- a/apps/web/src/stories/test-data-population-toolbar.stories.js
+++ b/apps/web/src/stories/test-data-population-toolbar.stories.js
@@ -61,7 +61,7 @@ function renderToolbarStory(args) {
       },
       onUnsafeFakerExpressionsChange: (isEnabled) => {
         args.onUnsafeFakerExpressionsChange?.(isEnabled);
-        log.textContent = `risky-faker:${isEnabled}`;
+        log.textContent = `unsafe-faker:${isEnabled}`;
       },
     },
   });
@@ -98,7 +98,7 @@ const meta = {
     generateBusy: false,
     generatePairwiseBusy: false,
     generateSchemaBusy: false,
-    unsafeFakerExpressions: true,
+    unsafeFakerExpressions: false,
     rowCount: 1,
     maxWidth: '',
     onGenerate: fn(),
@@ -152,7 +152,7 @@ export const Default = {
     docs: {
       description: {
         story:
-          'Shows the default horizontal toolbar composition: generation settings cog, Generate action, row count, and mode selector on one line. Open settings to review allow risky faker, then try **Generate** and confirm the log updates without needing the larger schema editor panel around it.',
+          'Shows the default horizontal toolbar composition: generation settings cog, Generate action, row count, and mode selector on one line. Open settings to review allow unsafe faker, then try **Generate** and confirm the log updates without needing the larger schema editor panel around it.',
       },
     },
   },
@@ -161,7 +161,9 @@ export const Default = {
     await expect(canvas.getByRole('button', { name: 'Generate' })).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
-    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
+    await expect(canvas.getByRole('checkbox', { name: 'allow unsafe faker' })).not.toBeChecked();
+    await userEvent.click(canvas.getByRole('checkbox', { name: 'allow unsafe faker' }));
+    await expect(canvas.getByText('unsafe-faker:true')).toBeVisible();
     await expect(canvas.getByRole('spinbutton', { name: 'How Many?' })).toHaveValue(1);
     await expect(canvas.getByRole('radio', { name: 'New Table' })).toBeChecked();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate' }));

--- a/apps/web/src/stories/test-data-population-toolbar.stories.js
+++ b/apps/web/src/stories/test-data-population-toolbar.stories.js
@@ -28,6 +28,7 @@ function renderToolbarStory(args) {
       generateBusy: args.generateBusy,
       generatePairwiseBusy: args.generatePairwiseBusy,
       generateSchemaBusy: args.generateSchemaBusy,
+      unsafeFakerExpressions: args.unsafeFakerExpressions,
       modeOptions: [
         { value: 'new-table', label: 'New Table' },
         { value: 'amend-table', label: 'Amend Table' },
@@ -58,6 +59,10 @@ function renderToolbarStory(args) {
         args.onModeChange?.(mode);
         log.textContent = `selected:${mode}`;
       },
+      onUnsafeFakerExpressionsChange: (isEnabled) => {
+        args.onUnsafeFakerExpressionsChange?.(isEnabled);
+        log.textContent = `risky-faker:${isEnabled}`;
+      },
     },
   });
 
@@ -83,7 +88,7 @@ const meta = {
         ),
       description: {
         component:
-          'TestDataPopulationToolbar is the composed MVC surface for the app-side generation actions, row count, and mode selector. Storybook now documents this visible layout seam directly instead of only through the full test-data panel.',
+          'TestDataPopulationToolbar is the composed MVC surface for the app-side generation actions, generation settings, row count, and mode selector. Storybook now documents this visible layout seam directly instead of only through the full test-data panel.',
       },
     },
   },
@@ -93,12 +98,14 @@ const meta = {
     generateBusy: false,
     generatePairwiseBusy: false,
     generateSchemaBusy: false,
+    unsafeFakerExpressions: true,
     rowCount: 1,
     maxWidth: '',
     onGenerate: fn(),
     onGenerateCombinations: fn(),
     onGenerateSchema: fn(),
     onModeChange: fn(),
+    onUnsafeFakerExpressionsChange: fn(),
   },
   argTypes: {
     selectedMode: {
@@ -122,6 +129,10 @@ const meta = {
       control: 'boolean',
       description: 'Disables the Grid to Enum Schema action when true.',
     },
+    unsafeFakerExpressions: {
+      control: 'boolean',
+      description: 'Initial browser generation setting for expression-style Faker helper arguments.',
+    },
     rowCount: {
       control: 'number',
       description: 'Initial count shown by the shared row-count control.',
@@ -141,7 +152,7 @@ export const Default = {
     docs: {
       description: {
         story:
-          'Shows the default horizontal toolbar composition: Generate action, row count, and mode selector on one line. Try **Generate** and confirm the log updates without needing the larger schema editor panel around it.',
+          'Shows the default horizontal toolbar composition: generation settings cog, Generate action, row count, and mode selector on one line. Open settings to review allow risky faker, then try **Generate** and confirm the log updates without needing the larger schema editor panel around it.',
       },
     },
   },
@@ -149,6 +160,8 @@ export const Default = {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button', { name: 'Generate' })).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Grid to Enum Schema' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: 'Generation settings' }));
+    await expect(canvas.getByRole('checkbox', { name: 'allow risky faker' })).toBeChecked();
     await expect(canvas.getByRole('spinbutton', { name: 'How Many?' })).toHaveValue(1);
     await expect(canvas.getByRole('radio', { name: 'New Table' })).toBeChecked();
     await userEvent.click(canvas.getByRole('button', { name: 'Generate' }));

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1353,6 +1353,116 @@ body.theme-dark .helpicon {
   vertical-align: -0.2rem;
 }
 
+.population-generation-settings {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+button.population-generation-settings__button {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--panel-bg) 88%, #ebf9f2 12%);
+  color: var(--page-text);
+  box-shadow: none;
+  line-height: 1;
+}
+
+button.population-generation-settings__button:hover,
+button.population-generation-settings__button[aria-expanded='true'] {
+  background: color-mix(in srgb, var(--panel-bg) 78%, #a9d6e5 22%);
+  border-color: #61a5c2;
+}
+
+.population-generation-settings__icon,
+.population-generation-settings__close-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.population-generation-settings__dialog {
+  position: absolute;
+  z-index: 1000;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 16rem;
+  max-width: min(20rem, calc(100vw - 2rem));
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--panel-bg);
+  color: var(--page-text);
+  box-shadow: 0 0.45rem 1.2rem rgb(0 0 0 / 16%);
+}
+
+.population-generation-settings__dialog-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.population-generation-settings__dialog-head strong {
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+button.population-generation-settings__close {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1.7rem;
+  min-width: 1.7rem;
+  height: 1.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--page-text);
+  line-height: 1;
+}
+
+button.population-generation-settings__close:hover {
+  background: color-mix(in srgb, var(--panel-bg) 78%, #a9d6e5 22%);
+}
+
+.population-generation-setting {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.35rem 0.45rem;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--panel-bg) 90%, #ebf9f2 10%);
+  font-size: 0.9rem;
+  line-height: 1.25;
+  white-space: normal;
+}
+
+.population-generation-setting input {
+  margin: 0;
+}
+
+.population-generation-setting .helpicon {
+  justify-self: end;
+}
+
 .shared-generator-options-wrapper,
 .generator-options-wrapper {
   flex: 1 1 100%;

--- a/docs-src/docs/040-test-data/faker/010-helpers.md
+++ b/docs-src/docs/040-test-data/faker/010-helpers.md
@@ -42,6 +42,26 @@ helpers.mustache("Hello {{name}}", { name: "Ada" })
 helpers.fromRegExp("[A-Z]{2}[0-9]{3}")
 ```
 
+## Risky Helper Variants
+
+AnyWayData accepts literal helper arguments by default. Literal arguments include strings, numbers, booleans, `null`, arrays, and plain objects that contain only literal values.
+
+Some Faker helper variants accept JavaScript expressions such as callback functions. These are **risky** because they execute expression-style schema text. Only enable them for schemas you trust.
+
+| Helper command | Safe by default | Risky variant |
+| --- | --- | --- |
+| `helpers.mustache` | `helpers.mustache("Hello {{name}}", { name: "Ada" })` | `helpers.mustache("Hello {{name}}", { name: () => this.person.firstName() })` |
+| `helpers.maybe` | not available in safe mode because its first argument is a callback | `helpers.maybe(() => "enabled", { probability: 1 })` |
+| `helpers.multiple` | not available in safe mode because its first argument is a callback | `helpers.multiple(() => this.person.firstName(), { count: 3 })` |
+| `helpers.uniqueArray` | `helpers.uniqueArray(["red", "green", "blue"], 2)` | `helpers.uniqueArray(() => this.person.firstName(), 5)` |
+
+Opt in only when the schema source is trusted:
+
+- Web UI: open the **Generation settings** cog in the Test Data toolbar and enable `allow risky faker`.
+- CLI: add `--unsafe-faker-expressions`.
+- REST API: send `unsafeFakerExpressions: true` in the JSON body, or use `?unsafeFakerExpressions=true` with `/v1/generate/fromschema`.
+- MCP: pass `unsafeFakerExpressions: true` in the `generate_data_from_spec` or `amend_data_from_spec` tool arguments.
+
 ## Helper Methods
 
 ### `helpers.arrayElement`
@@ -114,7 +134,7 @@ helpers.multiple(() => this.person.firstName(), { count: 3 })
 
 - Many helper functions can return arrays or objects depending on method and inputs.
 - Prefer scalar-returning helpers when using grid/display flows that expect single values.
-- Some Faker helper callback shapes are not supported in browser schema text. Use the executable schema examples on this page when copying examples into AnyWayData.
+- Some Faker helper callback shapes require the risky faker opt-in. Use literal helper arguments unless you explicitly trust the schema source.
 
 ## Faker Reference
 

--- a/docs-src/docs/040-test-data/faker/010-helpers.md
+++ b/docs-src/docs/040-test-data/faker/010-helpers.md
@@ -42,13 +42,13 @@ helpers.mustache("Hello {{name}}", { name: "Ada" })
 helpers.fromRegExp("[A-Z]{2}[0-9]{3}")
 ```
 
-## Risky Helper Variants
+## Unsafe Helper Variants
 
 AnyWayData accepts literal helper arguments by default. Literal arguments include strings, numbers, booleans, `null`, arrays, and plain objects that contain only literal values.
 
-Some Faker helper variants accept JavaScript expressions such as callback functions. These are **risky** because they execute expression-style schema text. Only enable them for schemas you trust.
+Some Faker helper variants accept JavaScript expressions such as callback functions. These are **unsafe** because they execute expression-style schema text. Only enable them for schemas you trust.
 
-| Helper command | Safe by default | Risky variant |
+| Helper command | Safe by default | Unsafe variant |
 | --- | --- | --- |
 | `helpers.mustache` | `helpers.mustache("Hello {{name}}", { name: "Ada" })` | `helpers.mustache("Hello {{name}}", { name: () => this.person.firstName() })` |
 | `helpers.maybe` | not available in safe mode because its first argument is a callback | `helpers.maybe(() => "enabled", { probability: 1 })` |
@@ -57,9 +57,9 @@ Some Faker helper variants accept JavaScript expressions such as callback functi
 
 Opt in only when the schema source is trusted:
 
-- Web UI: open the **Generation settings** cog in the Test Data toolbar and enable `allow risky faker`.
+- Web UI: open the **Generation settings** cog in the Test Data toolbar and enable `allow unsafe faker`.
 - CLI: add `--unsafe-faker-expressions`.
-- REST API: send `unsafeFakerExpressions: true` in the JSON body, or use `?unsafeFakerExpressions=true` with `/v1/generate/fromschema`.
+- REST API: send `unsafeFakerExpressions: true` in the `/v1/generate` or `/v1/generate/amend` JSON body, or use `?unsafeFakerExpressions=true` with `/v1/generate/fromschema`.
 - MCP: pass `unsafeFakerExpressions: true` in the `generate_data_from_spec` or `amend_data_from_spec` tool arguments.
 
 ## Helper Methods
@@ -103,8 +103,10 @@ helpers.shuffle(["a", "b", "c"], { inplace: false })
 ### `helpers.uniqueArray`
 
 ```txt
-helpers.uniqueArray(this.word.sample, 5)
+helpers.uniqueArray(["red", "green", "blue"], 2)
 ```
+
+The callback form `helpers.uniqueArray(() => this.word.sample(), 5)` is an unsafe variant and requires the unsafe faker opt-in.
 
 ### `helpers.weightedArrayElement`
 
@@ -134,7 +136,7 @@ helpers.multiple(() => this.person.firstName(), { count: 3 })
 
 - Many helper functions can return arrays or objects depending on method and inputs.
 - Prefer scalar-returning helpers when using grid/display flows that expect single values.
-- Some Faker helper callback shapes require the risky faker opt-in. Use literal helper arguments unless you explicitly trust the schema source.
+- Some Faker helper callback shapes require the unsafe faker opt-in. Use literal helper arguments unless you explicitly trust the schema source.
 
 ## Faker Reference
 

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -154,6 +154,7 @@ Generation mode behavior:
 
 - REST generation endpoints currently run in buffered mode.
 - Stream-mode generation behavior is available via the core helper/CLI paths, not via `/v1/generate`.
+- REST generation endpoints are safe-by-default for faker helper arguments. To allow risky helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, send `unsafeFakerExpressions: true` in the JSON body, or pass `?unsafeFakerExpressions=true` to `/v1/generate/fromschema`. Only enable this for trusted schemas.
 
 ## Schema Formatting
 
@@ -208,6 +209,21 @@ curl -X POST "http://localhost:3000/v1/generate/fromschema?outputFormat=markdown
   -H "Content-Type: text/plain" \
   --data-binary $'# markdown sample\n\nName\nBob\n\n# numeric id\nId\n1'
 ```
+
+Generate with a trusted risky helper variant:
+
+```bash
+curl -X POST http://localhost:3000/v1/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "textSpec": "Greeting\nhelpers.mustache(\"Hello {{name}}\", { name: () => \"Ada\" })",
+    "rowCount": 1,
+    "outputFormat": "json",
+    "unsafeFakerExpressions": true
+  }'
+```
+
+For more helper examples and the safe/risky split, see [Faker Helpers](/docs/test-data/faker/helpers).
 
 Amend imported data (CSV input to tab-delimited output):
 
@@ -270,4 +286,3 @@ curl http://localhost:3000/openapi.json
 
 - If you run on a non-default port, replace `3000` in all examples.
 - For MCP tool integrations, see [MCP](/docs/interfaces-and-deployment/mcp).
-

--- a/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
+++ b/docs-src/docs/070-interfaces-and-deployment/030-rest-api.md
@@ -154,7 +154,7 @@ Generation mode behavior:
 
 - REST generation endpoints currently run in buffered mode.
 - Stream-mode generation behavior is available via the core helper/CLI paths, not via `/v1/generate`.
-- REST generation endpoints are safe-by-default for faker helper arguments. To allow risky helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, send `unsafeFakerExpressions: true` in the JSON body, or pass `?unsafeFakerExpressions=true` to `/v1/generate/fromschema`. Only enable this for trusted schemas.
+- REST generation endpoints are safe-by-default for faker helper arguments. To allow unsafe helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, send `unsafeFakerExpressions: true` in the `/v1/generate` or `/v1/generate/amend` JSON body, or pass `?unsafeFakerExpressions=true` to `/v1/generate/fromschema`. Only enable this for trusted schemas.
 
 ## Schema Formatting
 
@@ -210,7 +210,7 @@ curl -X POST "http://localhost:3000/v1/generate/fromschema?outputFormat=markdown
   --data-binary $'# markdown sample\n\nName\nBob\n\n# numeric id\nId\n1'
 ```
 
-Generate with a trusted risky helper variant:
+Generate with a trusted unsafe helper variant:
 
 ```bash
 curl -X POST http://localhost:3000/v1/generate \
@@ -223,7 +223,7 @@ curl -X POST http://localhost:3000/v1/generate \
   }'
 ```
 
-For more helper examples and the safe/risky split, see [Faker Helpers](/docs/test-data/faker/helpers).
+For more helper examples and the safe/unsafe split, see [Faker Helpers](/docs/test-data/faker/helpers).
 
 Amend imported data (CSV input to tab-delimited output):
 

--- a/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
+++ b/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
@@ -103,6 +103,7 @@ Common tools include:
 Important:
 
 - MCP enforces safe faker argument validation (literal args only by default).
+- To allow risky helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, pass `unsafeFakerExpressions: true` in the `generate_data_from_spec` or `amend_data_from_spec` tool arguments.
 - `amend_data_from_spec` accepts `stream` for compatibility but ignores it (always buffered).
 - MCP does not expose OpenAPI/Swagger.
 - For HTTP/OpenAPI use cases, see [REST API](/docs/interfaces-and-deployment/rest-api).
@@ -132,8 +133,11 @@ Example `tools/call` payload:
       "rowCount": 2,
       "outputFormat": "json",
       "trimInputFieldsCsv": "Name",
+      "unsafeFakerExpressions": false,
       "stream": true
     }
   }
 }
 ```
+
+Use `unsafeFakerExpressions: true` only when the MCP host is sending a trusted schema. For the helper variants that require this flag, see [Faker Helpers](/docs/test-data/faker/helpers).

--- a/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
+++ b/docs-src/docs/070-interfaces-and-deployment/040-mcp.md
@@ -103,7 +103,7 @@ Common tools include:
 Important:
 
 - MCP enforces safe faker argument validation (literal args only by default).
-- To allow risky helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, pass `unsafeFakerExpressions: true` in the `generate_data_from_spec` or `amend_data_from_spec` tool arguments.
+- To allow unsafe helper variants such as `helpers.mustache("Hello {{name}}", { name: () => "Ada" })`, pass `unsafeFakerExpressions: true` in the `generate_data_from_spec` or `amend_data_from_spec` tool arguments.
 - `amend_data_from_spec` accepts `stream` for compatibility but ignores it (always buffered).
 - MCP does not expose OpenAPI/Swagger.
 - For HTTP/OpenAPI use cases, see [REST API](/docs/interfaces-and-deployment/rest-api).

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -152,6 +152,14 @@ To allow expression-style faker arguments, opt in explicitly:
 anywaydata generate -i input.txt -n 10 -f csv --unsafe-faker-expressions
 ```
 
+This is required for risky helper variants that use callbacks or other expression-style arguments, for example:
+
+```txt
+helpers.mustache("Hello {{name}}", { name: () => this.person.firstName() })
+```
+
+Use the flag only for schema files you trust. For more examples, see [Faker Helpers](/docs/test-data/faker/helpers).
+
 ## Choose CLI vs API/MCP
 
 - Choose **CLI** for local scripts and shell pipelines.

--- a/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
+++ b/docs-src/docs/070-interfaces-and-deployment/050-cli-node-and-bun.md
@@ -152,7 +152,7 @@ To allow expression-style faker arguments, opt in explicitly:
 anywaydata generate -i input.txt -n 10 -f csv --unsafe-faker-expressions
 ```
 
-This is required for risky helper variants that use callbacks or other expression-style arguments, for example:
+This is required for unsafe helper variants that use callbacks or other expression-style arguments, for example:
 
 ```txt
 helpers.mustache("Hello {{name}}", { name: () => this.person.firstName() })

--- a/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-controller.js
+++ b/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-controller.js
@@ -11,7 +11,7 @@ class DataPopulationPanelController {
       storedSchemasEnabled: props.storedSchemasEnabled === true,
       storedSchemasProps: { ...(props.storedSchemasProps || {}) },
       generateSchemaBusy: props.generateSchemaBusy === true,
-      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
+      unsafeFakerExpressions: props.unsafeFakerExpressions === true,
     };
   }
 

--- a/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-controller.js
+++ b/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-controller.js
@@ -11,6 +11,7 @@ class DataPopulationPanelController {
       storedSchemasEnabled: props.storedSchemasEnabled === true,
       storedSchemasProps: { ...(props.storedSchemasProps || {}) },
       generateSchemaBusy: props.generateSchemaBusy === true,
+      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
     };
   }
 
@@ -32,6 +33,7 @@ class DataPopulationPanelController {
         ? { ...this.state.storedSchemasProps, ...nextProps.storedSchemasProps }
         : this.state.storedSchemasProps,
       generateSchemaBusy: nextProps.generateSchemaBusy ?? this.state.generateSchemaBusy,
+      unsafeFakerExpressions: nextProps.unsafeFakerExpressions ?? this.state.unsafeFakerExpressions,
     };
   }
 
@@ -52,6 +54,14 @@ class DataPopulationPanelController {
       selectedMode: mode,
     };
     this.callbacks.onModeChange?.(mode);
+  }
+
+  handleUnsafeFakerExpressionsChange(isEnabled) {
+    this.state = {
+      ...this.state,
+      unsafeFakerExpressions: isEnabled === true,
+    };
+    this.callbacks.onUnsafeFakerExpressionsChange?.(this.state.unsafeFakerExpressions);
   }
 }
 

--- a/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-view.js
+++ b/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-view.js
@@ -47,12 +47,14 @@ class DataPopulationPanelView {
         rowCountProps: state.rowCountProps,
         actionIds: state.actionIds,
         generateSchemaBusy: state.generateSchemaBusy,
+        unsafeFakerExpressions: state.unsafeFakerExpressions,
       },
       callbacks: {
         onGenerate: this.callbacks.onGenerate,
         onGeneratePairwise: this.callbacks.onGeneratePairwise,
         onGenerateSchemaFromGrid: this.callbacks.onGenerateSchemaFromGrid,
         onModeChange: (mode) => this.controller.handleModeChange(mode),
+        onUnsafeFakerExpressionsChange: (isEnabled) => this.controller.handleUnsafeFakerExpressionsChange(isEnabled),
       },
     });
 
@@ -85,6 +87,7 @@ class DataPopulationPanelView {
       rowCountProps: state.rowCountProps,
       actionIds: state.actionIds,
       generateSchemaBusy: state.generateSchemaBusy,
+      unsafeFakerExpressions: state.unsafeFakerExpressions,
     });
     this.schemaPanel?.update?.({
       className: 'test-data-schema-edit-zone shared-schema-section',
@@ -133,6 +136,10 @@ class DataPopulationPanelView {
 
   setGenerateSchemaBusy(isBusy) {
     this.toolbar?.setGenerateSchemaBusy?.(isBusy);
+  }
+
+  getUnsafeFakerExpressions() {
+    return this.toolbar?.getUnsafeFakerExpressions?.() ?? this.controller.getState().unsafeFakerExpressions;
   }
 
   getSchemaDefinition() {

--- a/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-view.js
+++ b/packages/core-ui/js/gui_components/app/data-population-panel/data-population-panel-view.js
@@ -67,7 +67,10 @@ class DataPopulationPanelView {
         schemaDefinitionRootDataRole: 'schema-definition-root',
         ariaLabel: 'Test data schema panel',
         ids: this.ids,
-        schemaDefinitionProps: state.schemaDefinitionProps,
+        schemaDefinitionProps: {
+          ...state.schemaDefinitionProps,
+          getUnsafeFakerExpressions: () => this.getUnsafeFakerExpressions(),
+        },
         storedSchemasEnabled: state.storedSchemasEnabled,
         storedSchemasProps: state.storedSchemasProps,
       },
@@ -94,7 +97,10 @@ class DataPopulationPanelView {
       rootDataRole: 'test-data-schema-panel-root',
       schemaDefinitionRootDataRole: 'schema-definition-root',
       ariaLabel: 'Test data schema panel',
-      schemaDefinitionProps: state.schemaDefinitionProps,
+      schemaDefinitionProps: {
+        ...state.schemaDefinitionProps,
+        getUnsafeFakerExpressions: () => this.getUnsafeFakerExpressions(),
+      },
       storedSchemasEnabled: state.storedSchemasEnabled,
       storedSchemasProps: state.storedSchemasProps,
     });

--- a/packages/core-ui/js/gui_components/app/data-population-panel/index.js
+++ b/packages/core-ui/js/gui_components/app/data-population-panel/index.js
@@ -106,6 +106,9 @@ function createDataPopulationPanelComponent({ root, props = {}, services = {}, c
     getSchemaText() {
       return view.getSchemaDefinition()?.getSchemaText?.() || '';
     },
+    getUnsafeFakerExpressions() {
+      return view.getUnsafeFakerExpressions();
+    },
     replaceSchemaRows(rows) {
       return view.getSchemaDefinition()?.replaceRows?.(rows);
     },

--- a/packages/core-ui/js/gui_components/app/population-actions/index.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/index.js
@@ -48,6 +48,13 @@ function createPopulationActionsComponent({
       controller.updateProps({ generateSchemaBusy: isBusy === true });
       view.render();
     },
+    setUnsafeFakerExpressions(isEnabled) {
+      controller.updateProps({ unsafeFakerExpressions: isEnabled === true });
+      view.render();
+    },
+    getUnsafeFakerExpressions() {
+      return controller.getState().unsafeFakerExpressions === true;
+    },
     getState() {
       return controller.getState();
     },

--- a/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
@@ -17,12 +17,12 @@ class PopulationActionsController {
       generateSchemaHelpLabel: props.generateSchemaHelpLabel || 'Show grid to schema help',
       generateSchemaVisible: props.generateSchemaVisible !== false,
       unsafeFakerExpressionsVisible: props.unsafeFakerExpressionsVisible === true,
-      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
-      unsafeFakerExpressionsLabel: props.unsafeFakerExpressionsLabel || 'allow risky faker',
+      unsafeFakerExpressions: props.unsafeFakerExpressions === true,
+      unsafeFakerExpressionsLabel: props.unsafeFakerExpressionsLabel || 'allow unsafe faker',
       unsafeFakerExpressionsHelpHtml:
         props.unsafeFakerExpressionsHelpHtml ||
         '<p>Allows expression-style Faker helper arguments such as functions in helper data objects. Example: <code>helpers.mustache("Hi {{name}}", { name: () => this.person.firstName() })</code>.</p><p>Only use schemas you trust. See <a href="/docs/test-data/faker/helpers">Faker Helpers</a>.</p>',
-      unsafeFakerExpressionsHelpLabel: props.unsafeFakerExpressionsHelpLabel || 'Show risky Faker help',
+      unsafeFakerExpressionsHelpLabel: props.unsafeFakerExpressionsHelpLabel || 'Show unsafe Faker help',
       generationSettingsOpen: props.generationSettingsOpen === true,
       generationSettingsLabel: props.generationSettingsLabel || 'Generation settings',
       statusVisible: props.statusVisible === true,

--- a/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
@@ -1,3 +1,7 @@
+import { buildDocsUrl } from '@anywaydata/site-config';
+
+const DEFAULT_UNSAFE_FAKER_HELP_HTML = `<p>Allows expression-style Faker helper arguments such as functions in helper data objects. Example: <code>helpers.mustache("Hi {{name}}", { name: () => this.person.firstName() })</code>.</p><p>Only use schemas you trust. See <a href="${buildDocsUrl('test-data/faker/helpers')}">Faker Helpers</a>.</p>`;
+
 class PopulationActionsController {
   constructor({ props = {}, callbacks = {} } = {}) {
     this.callbacks = callbacks;
@@ -19,9 +23,7 @@ class PopulationActionsController {
       unsafeFakerExpressionsVisible: props.unsafeFakerExpressionsVisible === true,
       unsafeFakerExpressions: props.unsafeFakerExpressions === true,
       unsafeFakerExpressionsLabel: props.unsafeFakerExpressionsLabel || 'allow unsafe faker',
-      unsafeFakerExpressionsHelpHtml:
-        props.unsafeFakerExpressionsHelpHtml ||
-        '<p>Allows expression-style Faker helper arguments such as functions in helper data objects. Example: <code>helpers.mustache("Hi {{name}}", { name: () => this.person.firstName() })</code>.</p><p>Only use schemas you trust. See <a href="/docs/test-data/faker/helpers">Faker Helpers</a>.</p>',
+      unsafeFakerExpressionsHelpHtml: props.unsafeFakerExpressionsHelpHtml || DEFAULT_UNSAFE_FAKER_HELP_HTML,
       unsafeFakerExpressionsHelpLabel: props.unsafeFakerExpressionsHelpLabel || 'Show unsafe Faker help',
       generationSettingsOpen: props.generationSettingsOpen === true,
       generationSettingsLabel: props.generationSettingsLabel || 'Generation settings',

--- a/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/population-actions-controller.js
@@ -16,6 +16,15 @@ class PopulationActionsController {
       generatePairwiseHelpLabel: props.generatePairwiseHelpLabel || 'Show pairwise generation help',
       generateSchemaHelpLabel: props.generateSchemaHelpLabel || 'Show grid to schema help',
       generateSchemaVisible: props.generateSchemaVisible !== false,
+      unsafeFakerExpressionsVisible: props.unsafeFakerExpressionsVisible === true,
+      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
+      unsafeFakerExpressionsLabel: props.unsafeFakerExpressionsLabel || 'allow risky faker',
+      unsafeFakerExpressionsHelpHtml:
+        props.unsafeFakerExpressionsHelpHtml ||
+        '<p>Allows expression-style Faker helper arguments such as functions in helper data objects. Example: <code>helpers.mustache("Hi {{name}}", { name: () => this.person.firstName() })</code>.</p><p>Only use schemas you trust. See <a href="/docs/test-data/faker/helpers">Faker Helpers</a>.</p>',
+      unsafeFakerExpressionsHelpLabel: props.unsafeFakerExpressionsHelpLabel || 'Show risky Faker help',
+      generationSettingsOpen: props.generationSettingsOpen === true,
+      generationSettingsLabel: props.generationSettingsLabel || 'Generation settings',
       statusVisible: props.statusVisible === true,
       roleNames: {
         generateButton: props.roleNames?.generateButton || 'generate-button',
@@ -44,6 +53,16 @@ class PopulationActionsController {
       generatePairwiseHelpLabel: nextProps.generatePairwiseHelpLabel ?? this.state.generatePairwiseHelpLabel,
       generateSchemaHelpLabel: nextProps.generateSchemaHelpLabel ?? this.state.generateSchemaHelpLabel,
       generateSchemaVisible: nextProps.generateSchemaVisible ?? this.state.generateSchemaVisible,
+      unsafeFakerExpressionsVisible:
+        nextProps.unsafeFakerExpressionsVisible ?? this.state.unsafeFakerExpressionsVisible,
+      unsafeFakerExpressions: nextProps.unsafeFakerExpressions ?? this.state.unsafeFakerExpressions,
+      unsafeFakerExpressionsLabel: nextProps.unsafeFakerExpressionsLabel ?? this.state.unsafeFakerExpressionsLabel,
+      unsafeFakerExpressionsHelpHtml:
+        nextProps.unsafeFakerExpressionsHelpHtml ?? this.state.unsafeFakerExpressionsHelpHtml,
+      unsafeFakerExpressionsHelpLabel:
+        nextProps.unsafeFakerExpressionsHelpLabel ?? this.state.unsafeFakerExpressionsHelpLabel,
+      generationSettingsOpen: nextProps.generationSettingsOpen ?? this.state.generationSettingsOpen,
+      generationSettingsLabel: nextProps.generationSettingsLabel ?? this.state.generationSettingsLabel,
       statusVisible: nextProps.statusVisible ?? this.state.statusVisible,
       roleNames: nextProps.roleNames
         ? {
@@ -68,6 +87,28 @@ class PopulationActionsController {
 
   handleGenerateSchemaFromGrid() {
     this.callbacks.onGenerateSchemaFromGrid?.();
+  }
+
+  handleUnsafeFakerExpressionsChange(isEnabled) {
+    this.state = {
+      ...this.state,
+      unsafeFakerExpressions: isEnabled === true,
+    };
+    this.callbacks.onUnsafeFakerExpressionsChange?.(this.state.unsafeFakerExpressions);
+  }
+
+  toggleGenerationSettings() {
+    this.state = {
+      ...this.state,
+      generationSettingsOpen: !this.state.generationSettingsOpen,
+    };
+  }
+
+  closeGenerationSettings() {
+    this.state = {
+      ...this.state,
+      generationSettingsOpen: false,
+    };
   }
 }
 

--- a/packages/core-ui/js/gui_components/app/population-actions/population-actions-view.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/population-actions-view.js
@@ -104,6 +104,11 @@ class PopulationActionsView {
     }
 
     this.root.innerHTML = this.template();
+    this.bindElements();
+    this.render();
+  }
+
+  bindElements() {
     this.generateButton = this.root.querySelector(`[data-role="${this.getRoleName('generateButton')}"]`);
     this.generatePairwiseButton = this.root.querySelector(
       `[data-role="${this.getRoleName('generatePairwiseButton')}"]`
@@ -124,7 +129,25 @@ class PopulationActionsView {
     this.generationSettingsButton?.addEventListener('click', this.handleGenerationSettingsClick);
     this.generationSettingsCloseButton?.addEventListener('click', this.handleGenerationSettingsClose);
     this.unsafeFakerExpressionsCheckbox?.addEventListener('change', this.handleUnsafeFakerExpressionsChange);
-    this.render();
+  }
+
+  unbindElements() {
+    this.generateButton?.removeEventListener('click', this.handleGenerate);
+    this.generatePairwiseButton?.removeEventListener('click', this.handleGeneratePairwise);
+    this.generateSchemaButton?.removeEventListener('click', this.handleGenerateSchemaFromGrid);
+    this.generationSettingsButton?.removeEventListener('click', this.handleGenerationSettingsClick);
+    this.generationSettingsCloseButton?.removeEventListener('click', this.handleGenerationSettingsClose);
+    this.unsafeFakerExpressionsCheckbox?.removeEventListener('change', this.handleUnsafeFakerExpressionsChange);
+  }
+
+  rebuildTemplate() {
+    this.syncGenerationSettingsDocumentClick({
+      unsafeFakerExpressionsVisible: false,
+      generationSettingsOpen: false,
+    });
+    this.unbindElements();
+    this.root.innerHTML = this.template();
+    this.bindElements();
   }
 
   template() {
@@ -230,6 +253,10 @@ class PopulationActionsView {
 
   render() {
     const state = this.controller.getState();
+    const hasGenerationSettings = Boolean(this.generationSettingsContainer);
+    if (hasGenerationSettings !== (state.unsafeFakerExpressionsVisible === true)) {
+      this.rebuildTemplate();
+    }
     if (this.generateButton) {
       this.generateButton.disabled = state.generateBusy === true;
       this.generateButton.setAttribute('aria-disabled', state.generateBusy === true ? 'true' : 'false');
@@ -266,12 +293,7 @@ class PopulationActionsView {
       unsafeFakerExpressionsVisible: false,
       generationSettingsOpen: false,
     });
-    this.generateButton?.removeEventListener('click', this.handleGenerate);
-    this.generatePairwiseButton?.removeEventListener('click', this.handleGeneratePairwise);
-    this.generateSchemaButton?.removeEventListener('click', this.handleGenerateSchemaFromGrid);
-    this.generationSettingsButton?.removeEventListener('click', this.handleGenerationSettingsClick);
-    this.generationSettingsCloseButton?.removeEventListener('click', this.handleGenerationSettingsClose);
-    this.unsafeFakerExpressionsCheckbox?.removeEventListener('change', this.handleUnsafeFakerExpressionsChange);
+    this.unbindElements();
     this.root.replaceChildren();
   }
 }

--- a/packages/core-ui/js/gui_components/app/population-actions/population-actions-view.js
+++ b/packages/core-ui/js/gui_components/app/population-actions/population-actions-view.js
@@ -12,6 +12,18 @@ class PopulationActionsView {
     this.handleGenerate = () => this.controller.handleGenerate();
     this.handleGeneratePairwise = () => this.controller.handleGeneratePairwise();
     this.handleGenerateSchemaFromGrid = () => this.controller.handleGenerateSchemaFromGrid();
+    this.handleUnsafeFakerExpressionsChange = (event) =>
+      this.controller.handleUnsafeFakerExpressionsChange(event.target?.checked === true);
+    this.handleGenerationSettingsClick = () => {
+      this.controller.toggleGenerationSettings();
+      this.render();
+    };
+    this.handleGenerationSettingsClose = () => {
+      this.controller.closeGenerationSettings();
+      this.render();
+    };
+    this.handleGenerationSettingsDocumentClick = (event) => this.handleDocumentClickOutsideGenerationSettings(event);
+    this.isGenerationSettingsDocumentClickBound = false;
   }
 
   buildOptionalIdAttr(id) {
@@ -34,6 +46,58 @@ class PopulationActionsView {
       ></button>`;
   }
 
+  renderGenerationSettings(state) {
+    if (state.unsafeFakerExpressionsVisible !== true) {
+      return '';
+    }
+
+    return `
+      <span class="population-generation-settings">
+        <button
+          type="button"
+          class="population-generation-settings__button"
+          data-role="generation-settings-button"
+          aria-label="${escapeHtml(state.generationSettingsLabel)}"
+          title="${escapeHtml(state.generationSettingsLabel)}"
+          aria-expanded="${state.generationSettingsOpen ? 'true' : 'false'}"
+        >
+          ${renderIconHtml('settings', { className: 'app-icon population-generation-settings__icon' })}
+        </button>
+        <div
+          class="population-generation-settings__dialog"
+          data-role="generation-settings-dialog"
+          role="dialog"
+          aria-label="${escapeHtml(state.generationSettingsLabel)}"
+          ${state.generationSettingsOpen ? '' : 'hidden'}
+        >
+          <div class="population-generation-settings__dialog-head">
+            <strong>${escapeHtml(state.generationSettingsLabel)}</strong>
+            <button
+              type="button"
+              class="population-generation-settings__close"
+              data-role="generation-settings-close"
+              aria-label="Close settings"
+              title="Close settings"
+            >
+              ${renderIconHtml('x', { className: 'app-icon population-generation-settings__close-icon' })}
+            </button>
+          </div>
+          <label class="population-generation-setting" data-role="unsafe-faker-expressions-setting">
+            <input
+              type="checkbox"
+              data-role="unsafe-faker-expressions-checkbox"
+              ${state.unsafeFakerExpressions ? 'checked' : ''}
+            >
+            <span>${escapeHtml(state.unsafeFakerExpressionsLabel)}</span>
+            ${this.renderHelpButton({
+              helpHtml: state.unsafeFakerExpressionsHelpHtml,
+              ariaLabel: state.unsafeFakerExpressionsHelpLabel,
+            })}
+          </label>
+        </div>
+      </span>`;
+  }
+
   mount() {
     if (!this.root) {
       throw new Error('PopulationActionsView requires a root element');
@@ -48,10 +112,18 @@ class PopulationActionsView {
     this.generatePairwiseWrapper = this.root.querySelector(
       `[data-role="${this.getRoleName('generatePairwiseWrapper')}"]`
     );
+    this.generationSettingsButton = this.root.querySelector('[data-role="generation-settings-button"]');
+    this.generationSettingsContainer = this.root.querySelector('.population-generation-settings');
+    this.generationSettingsDialog = this.root.querySelector('[data-role="generation-settings-dialog"]');
+    this.generationSettingsCloseButton = this.root.querySelector('[data-role="generation-settings-close"]');
+    this.unsafeFakerExpressionsCheckbox = this.root.querySelector('[data-role="unsafe-faker-expressions-checkbox"]');
 
     this.generateButton?.addEventListener('click', this.handleGenerate);
     this.generatePairwiseButton?.addEventListener('click', this.handleGeneratePairwise);
     this.generateSchemaButton?.addEventListener('click', this.handleGenerateSchemaFromGrid);
+    this.generationSettingsButton?.addEventListener('click', this.handleGenerationSettingsClick);
+    this.generationSettingsCloseButton?.addEventListener('click', this.handleGenerationSettingsClose);
+    this.unsafeFakerExpressionsCheckbox?.addEventListener('change', this.handleUnsafeFakerExpressionsChange);
     this.render();
   }
 
@@ -64,6 +136,7 @@ class PopulationActionsView {
 
     return `
       <span class="shared-button-with-help">
+        ${this.renderGenerationSettings(state)}
         ${this.renderHelpButton({
           helpHtml: state.generateHelpHtml,
           ariaLabel: state.generateHelpLabel,
@@ -129,6 +202,32 @@ class PopulationActionsView {
     return state.roleNames?.[key] || '';
   }
 
+  handleDocumentClickOutsideGenerationSettings(event) {
+    if (this.controller.getState().generationSettingsOpen !== true) {
+      return;
+    }
+    if (this.generationSettingsContainer?.contains(event.target)) {
+      return;
+    }
+
+    this.controller.closeGenerationSettings();
+    this.render();
+  }
+
+  syncGenerationSettingsDocumentClick(state) {
+    const shouldBind =
+      state.unsafeFakerExpressionsVisible === true && state.generationSettingsOpen === true && this.documentObj;
+    if (shouldBind && !this.isGenerationSettingsDocumentClickBound) {
+      this.documentObj.addEventListener('click', this.handleGenerationSettingsDocumentClick, true);
+      this.isGenerationSettingsDocumentClickBound = true;
+      return;
+    }
+    if (!shouldBind && this.isGenerationSettingsDocumentClickBound) {
+      this.documentObj.removeEventListener('click', this.handleGenerationSettingsDocumentClick, true);
+      this.isGenerationSettingsDocumentClickBound = false;
+    }
+  }
+
   render() {
     const state = this.controller.getState();
     if (this.generateButton) {
@@ -149,13 +248,30 @@ class PopulationActionsView {
     if (this.generatePairwiseWrapper) {
       this.generatePairwiseWrapper.style.display = state.pairwiseVisible ? 'inline-flex' : 'none';
     }
+    if (this.generationSettingsButton) {
+      this.generationSettingsButton.setAttribute('aria-expanded', state.generationSettingsOpen ? 'true' : 'false');
+    }
+    if (this.generationSettingsDialog) {
+      this.generationSettingsDialog.hidden = state.generationSettingsOpen !== true;
+    }
+    if (this.unsafeFakerExpressionsCheckbox) {
+      this.unsafeFakerExpressionsCheckbox.checked = state.unsafeFakerExpressions === true;
+    }
+    this.syncGenerationSettingsDocumentClick(state);
     this.services.updateHelpHints?.();
   }
 
   destroy() {
+    this.syncGenerationSettingsDocumentClick({
+      unsafeFakerExpressionsVisible: false,
+      generationSettingsOpen: false,
+    });
     this.generateButton?.removeEventListener('click', this.handleGenerate);
     this.generatePairwiseButton?.removeEventListener('click', this.handleGeneratePairwise);
     this.generateSchemaButton?.removeEventListener('click', this.handleGenerateSchemaFromGrid);
+    this.generationSettingsButton?.removeEventListener('click', this.handleGenerationSettingsClick);
+    this.generationSettingsCloseButton?.removeEventListener('click', this.handleGenerationSettingsClose);
+    this.unsafeFakerExpressionsCheckbox?.removeEventListener('change', this.handleUnsafeFakerExpressionsChange);
     this.root.replaceChildren();
   }
 }

--- a/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
+++ b/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
@@ -187,7 +187,7 @@ function createTestDataGenerationPanelManager({
       getMainGridExtras,
       getGenerationMode,
       getRequestedRowCount: () => state.dataPopulationPanel?.getRowCountInputValue?.(),
-      getUnsafeFakerExpressions: () => state.dataPopulationPanel?.getUnsafeFakerExpressions?.() ?? true,
+      getUnsafeFakerExpressions: () => state.dataPopulationPanel?.getUnsafeFakerExpressions?.() ?? false,
       setGenerateBusy: (isBusy) => state.dataPopulationPanel?.setGenerateBusy?.(isBusy),
       setGeneratePairwiseBusy: (isBusy) => state.dataPopulationPanel?.setGeneratePairwiseBusy?.(isBusy),
       setPairwiseVisible: (isVisible) => state.dataPopulationPanel?.setPairwiseVisible?.(isVisible),
@@ -419,7 +419,7 @@ function createTestDataGenerationPanelManager({
         }),
         storedSchemasEnabled: true,
         storedSchemasProps: {},
-        unsafeFakerExpressions: true,
+        unsafeFakerExpressions: false,
       },
       callbacks: {
         onGenerate: () => state.actionAdapter.generateTestData(),

--- a/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
+++ b/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
@@ -187,6 +187,7 @@ function createTestDataGenerationPanelManager({
       getMainGridExtras,
       getGenerationMode,
       getRequestedRowCount: () => state.dataPopulationPanel?.getRowCountInputValue?.(),
+      getUnsafeFakerExpressions: () => state.dataPopulationPanel?.getUnsafeFakerExpressions?.() ?? true,
       setGenerateBusy: (isBusy) => state.dataPopulationPanel?.setGenerateBusy?.(isBusy),
       setGeneratePairwiseBusy: (isBusy) => state.dataPopulationPanel?.setGeneratePairwiseBusy?.(isBusy),
       setPairwiseVisible: (isVisible) => state.dataPopulationPanel?.setPairwiseVisible?.(isVisible),
@@ -418,6 +419,7 @@ function createTestDataGenerationPanelManager({
         }),
         storedSchemasEnabled: true,
         storedSchemasProps: {},
+        unsafeFakerExpressions: true,
       },
       callbacks: {
         onGenerate: () => state.actionAdapter.generateTestData(),

--- a/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
+++ b/packages/core-ui/js/gui_components/app/test-data-grid/controller/test-data-grid-controller.js
@@ -406,10 +406,11 @@ function createTestDataGenerationPanelManager({
           RandExp: resolvedRandExpClass,
           getMethodPickerOptions,
           fakerCommands: FAKER_COMMANDS.filter((command) => command !== 'RegEx' && command.startsWith('helpers.')),
-          validateSchemaRows: (schemaRows) =>
+          validateSchemaRows: (schemaRows, validationOptions = {}) =>
             validateSharedSchemaRows({
               schemaRows,
               schemaRowsToDataRules,
+              unsafeFakerExpressions: validationOptions.unsafeFakerExpressions === true,
             }),
           getVisibleDomainCommandOptions: (currentValue) => {
             const options = getMethodPickerOptions(currentValue).filter((option) => option.sourceType === 'domain');

--- a/packages/core-ui/js/gui_components/app/test-data-grid/generation/test-data-generation-service.js
+++ b/packages/core-ui/js/gui_components/app/test-data-grid/generation/test-data-generation-service.js
@@ -62,7 +62,7 @@ function createTestDataGenerationService({
   setGenerateBusy = () => {},
   setGeneratePairwiseBusy = () => {},
   setPairwiseVisible = () => {},
-  getUnsafeFakerExpressions = () => true,
+  getUnsafeFakerExpressions = () => false,
   requestConfirm,
   recordLastUsedSchema = () => null,
   createGenerationSessionFn = createGenerationSession,

--- a/packages/core-ui/js/gui_components/app/test-data-grid/generation/test-data-generation-service.js
+++ b/packages/core-ui/js/gui_components/app/test-data-grid/generation/test-data-generation-service.js
@@ -62,6 +62,7 @@ function createTestDataGenerationService({
   setGenerateBusy = () => {},
   setGeneratePairwiseBusy = () => {},
   setPairwiseVisible = () => {},
+  getUnsafeFakerExpressions = () => true,
   requestConfirm,
   recordLastUsedSchema = () => null,
   createGenerationSessionFn = createGenerationSession,
@@ -93,6 +94,9 @@ function createTestDataGenerationService({
       TestDataGeneratorClass,
       faker,
       RandExp,
+      generatorOptions: {
+        unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
+      },
       buildRuleSpecFromSchemaRow,
       extractLiteralValueFromRuleSpec,
       extractRegexValueFromRuleSpec,
@@ -119,6 +123,7 @@ function createTestDataGenerationService({
     CombinationsTestDataGeneratorClass,
     createConfiguredGenerator,
     createGenerationSessionFn,
+    getUnsafeFakerExpressions,
     faker,
     RandExp,
   });

--- a/packages/core-ui/js/gui_components/app/test-data-population-toolbar/index.js
+++ b/packages/core-ui/js/gui_components/app/test-data-population-toolbar/index.js
@@ -71,6 +71,9 @@ function createTestDataPopulationToolbarComponent({
       controller.updateProps({ generateSchemaBusy: isBusy === true });
       view.setGenerateSchemaBusy(isBusy);
     },
+    getUnsafeFakerExpressions() {
+      return view.getUnsafeFakerExpressions();
+    },
     getState() {
       return controller.getState();
     },

--- a/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-controller.js
+++ b/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-controller.js
@@ -10,7 +10,7 @@ class TestDataPopulationToolbarController {
       generateBusy: props.generateBusy === true,
       generatePairwiseBusy: props.generatePairwiseBusy === true,
       generateSchemaBusy: props.generateSchemaBusy === true,
-      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
+      unsafeFakerExpressions: props.unsafeFakerExpressions === true,
     };
   }
 

--- a/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-controller.js
+++ b/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-controller.js
@@ -10,6 +10,7 @@ class TestDataPopulationToolbarController {
       generateBusy: props.generateBusy === true,
       generatePairwiseBusy: props.generatePairwiseBusy === true,
       generateSchemaBusy: props.generateSchemaBusy === true,
+      unsafeFakerExpressions: props.unsafeFakerExpressions !== false,
     };
   }
 
@@ -26,6 +27,7 @@ class TestDataPopulationToolbarController {
       generateBusy: nextProps.generateBusy ?? this.state.generateBusy,
       generatePairwiseBusy: nextProps.generatePairwiseBusy ?? this.state.generatePairwiseBusy,
       generateSchemaBusy: nextProps.generateSchemaBusy ?? this.state.generateSchemaBusy,
+      unsafeFakerExpressions: nextProps.unsafeFakerExpressions ?? this.state.unsafeFakerExpressions,
     };
   }
 
@@ -44,6 +46,14 @@ class TestDataPopulationToolbarController {
       selectedMode: mode,
     };
     this.callbacks.onModeChange?.(mode);
+  }
+
+  handleUnsafeFakerExpressionsChange(isEnabled) {
+    this.state = {
+      ...this.state,
+      unsafeFakerExpressions: isEnabled === true,
+    };
+    this.callbacks.onUnsafeFakerExpressionsChange?.(this.state.unsafeFakerExpressions);
   }
 }
 

--- a/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-view.js
+++ b/packages/core-ui/js/gui_components/app/test-data-population-toolbar/test-data-population-toolbar-view.js
@@ -68,12 +68,15 @@ class TestDataPopulationToolbarView {
         generateSchemaLabel: 'Grid to Enum Schema',
         generateSchemaHelpHtml: GRID_TO_SCHEMA_HELP_HTML,
         generateSchemaHelpLabel: 'Show grid to enum schema help',
+        unsafeFakerExpressionsVisible: true,
+        unsafeFakerExpressions: state.unsafeFakerExpressions,
         statusVisible: true,
       },
       callbacks: {
         onGenerate: this.callbacks.onGenerate,
         onGeneratePairwise: this.callbacks.onGeneratePairwise,
         onGenerateSchemaFromGrid: this.callbacks.onGenerateSchemaFromGrid,
+        onUnsafeFakerExpressionsChange: (isEnabled) => this.controller.handleUnsafeFakerExpressionsChange(isEnabled),
       },
     });
 
@@ -111,6 +114,8 @@ class TestDataPopulationToolbarView {
       generateSchemaLabel: 'Grid to Enum Schema',
       generateSchemaHelpHtml: GRID_TO_SCHEMA_HELP_HTML,
       generateSchemaHelpLabel: 'Show grid to enum schema help',
+      unsafeFakerExpressionsVisible: true,
+      unsafeFakerExpressions: state.unsafeFakerExpressions,
       statusVisible: true,
       generateSchemaBusy: state.generateSchemaBusy,
     });
@@ -163,6 +168,10 @@ class TestDataPopulationToolbarView {
 
   setGenerateSchemaBusy(isBusy) {
     this.populationActions?.setGenerateSchemaBusy?.(isBusy);
+  }
+
+  getUnsafeFakerExpressions() {
+    return this.populationActions?.getUnsafeFakerExpressions?.() ?? this.controller.getState().unsafeFakerExpressions;
   }
 }
 

--- a/packages/core-ui/js/gui_components/generator/generation/generator-schema-generation-service.js
+++ b/packages/core-ui/js/gui_components/generator/generation/generator-schema-generation-service.js
@@ -23,6 +23,7 @@ function createGeneratorSchemaGenerationService({
   schemaTextToDataRules,
   getSchemaText,
   TestDataGeneratorClass,
+  getUnsafeFakerExpressions = () => true,
   faker,
   RandExp,
 } = {}) {
@@ -55,6 +56,9 @@ function createGeneratorSchemaGenerationService({
       TestDataGeneratorClass,
       faker,
       RandExp,
+      generatorOptions: {
+        unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
+      },
       buildRuleSpecFromSchemaRow,
       extractLiteralValueFromRuleSpec,
       extractRegexValueFromRuleSpec,
@@ -80,6 +84,7 @@ function createGeneratorSchemaGenerationService({
     GenericDataTableClass: GenericDataTable,
     CombinationsTestDataGeneratorClass: CombinationsTestDataGenerator,
     createConfiguredGenerator,
+    getUnsafeFakerExpressions,
     faker,
     RandExp,
   });

--- a/packages/core-ui/js/gui_components/generator/generation/generator-schema-generation-service.js
+++ b/packages/core-ui/js/gui_components/generator/generation/generator-schema-generation-service.js
@@ -23,7 +23,7 @@ function createGeneratorSchemaGenerationService({
   schemaTextToDataRules,
   getSchemaText,
   TestDataGeneratorClass,
-  getUnsafeFakerExpressions = () => true,
+  getUnsafeFakerExpressions = () => false,
   faker,
   RandExp,
 } = {}) {

--- a/packages/core-ui/js/gui_components/generator/runtime/create-generator-page-defaults.js
+++ b/packages/core-ui/js/gui_components/generator/runtime/create-generator-page-defaults.js
@@ -19,8 +19,11 @@ function createGeneratorPageDefaults() {
         dataRulesToSchemaText,
       });
     },
-    validateSchemaRows(schemaRows) {
-      return validateSchemaRowsHelper({ schemaRows });
+    validateSchemaRows(schemaRows, validationOptions = {}) {
+      return validateSchemaRowsHelper({
+        schemaRows,
+        unsafeFakerExpressions: validationOptions.unsafeFakerExpressions === true,
+      });
     },
     dataRulesToSchemaText,
     sampleSchemaText: GENERATOR_DEFAULT_EXAMPLE_SCHEMA_TEXT,

--- a/packages/core-ui/js/gui_components/generator/runtime/generator-schema-rule-helpers.js
+++ b/packages/core-ui/js/gui_components/generator/runtime/generator-schema-rule-helpers.js
@@ -29,10 +29,11 @@ function schemaRowsToSpecWithTokens({ schemaRows, schemaTokens, dataRulesToSchem
   });
 }
 
-function validateSchemaRows({ schemaRows }) {
+function validateSchemaRows({ schemaRows, unsafeFakerExpressions = false }) {
   return validateSchemaRowsCore({
     schemaRows,
     schemaRowsToDataRules,
+    unsafeFakerExpressions,
   });
 }
 

--- a/packages/core-ui/js/gui_components/shared/schema-definition/shared-schema-definition-controller.js
+++ b/packages/core-ui/js/gui_components/shared/schema-definition/shared-schema-definition-controller.js
@@ -93,6 +93,7 @@ class SharedSchemaDefinitionController {
       onRowsChanged: this.callbacks.onRowsChanged,
       onSchemaTextChanged: this.callbacks.onSchemaTextChanged,
       validateSchemaRows: this.props.validateSchemaRows,
+      getUnsafeFakerExpressions: this.props.getUnsafeFakerExpressions,
       updatePairwiseButtonVisibility: this.props.updatePairwiseButtonVisibility,
       updateHelpHints: this.props.updateHelpHints,
       timerApi: this.props.timerApi,

--- a/packages/core-ui/js/gui_components/shared/test-data/generation/generation-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/generation/generation-controller.js
@@ -12,8 +12,14 @@ import {
 } from './generation-runtime.js';
 import { EnumParser } from '@anywaydata/core/data_generation/utils/enumParser.js';
 
-function createGeneratorFromDataRules({ dataRules = [], TestDataGeneratorClass, faker, RandExp }) {
-  const generator = new TestDataGeneratorClass(faker, RandExp);
+function createGeneratorFromDataRules({
+  dataRules = [],
+  TestDataGeneratorClass,
+  faker,
+  RandExp,
+  generatorOptions = {},
+}) {
+  const generator = new TestDataGeneratorClass(faker, RandExp, generatorOptions);
   generator.rulesParser.testDataRules.rules = dataRules.map((rule) => ({ ...rule }));
   return generator;
 }
@@ -62,8 +68,9 @@ function createConfiguredGeneratorFromSchemaText({
   TestDataGeneratorClass,
   faker,
   RandExp,
+  generatorOptions = {},
 }) {
-  const generator = new TestDataGeneratorClass(faker, RandExp);
+  const generator = new TestDataGeneratorClass(faker, RandExp, generatorOptions);
   if (typeof generator.importSpec === 'function' && typeof generator.compile === 'function') {
     generator.importSpec(String(schemaText ?? ''));
     generator.compile();
@@ -100,6 +107,7 @@ function createConfiguredGeneratorFromSchemaText({
         TestDataGeneratorClass,
         faker,
         RandExp,
+        generatorOptions,
       }),
     errors: [],
     dataRules: parseResult.dataRules,
@@ -116,6 +124,7 @@ function createConfiguredGeneratorFromSchemaRows({
   TestDataGeneratorClass,
   faker,
   RandExp,
+  generatorOptions = {},
   buildRuleSpecFromSchemaRow,
   extractLiteralValueFromRuleSpec,
   extractRegexValueFromRuleSpec,
@@ -147,10 +156,11 @@ function createConfiguredGeneratorFromSchemaRows({
       TestDataGeneratorClass,
       faker,
       RandExp,
+      generatorOptions,
     });
   }
 
-  const generator = new TestDataGeneratorClass(faker, RandExp);
+  const generator = new TestDataGeneratorClass(faker, RandExp, generatorOptions);
   generator.importSpec(schemaRowsToSpec(rows));
   generator.compile();
 

--- a/packages/core-ui/js/gui_components/shared/test-data/generation/ui-generation-session-service.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/generation/ui-generation-session-service.js
@@ -134,7 +134,7 @@ function createUiGenerationSessionService({
   CombinationsTestDataGeneratorClass,
   createConfiguredGenerator = null,
   createGenerationSessionFn = createGenerationSession,
-  getUnsafeFakerExpressions = () => true,
+  getUnsafeFakerExpressions = () => false,
   faker,
   RandExp,
 }) {

--- a/packages/core-ui/js/gui_components/shared/test-data/generation/ui-generation-session-service.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/generation/ui-generation-session-service.js
@@ -134,6 +134,7 @@ function createUiGenerationSessionService({
   CombinationsTestDataGeneratorClass,
   createConfiguredGenerator = null,
   createGenerationSessionFn = createGenerationSession,
+  getUnsafeFakerExpressions = () => true,
   faker,
   RandExp,
 }) {
@@ -180,6 +181,7 @@ function createUiGenerationSessionService({
       schemaSource,
       fakerInstance: faker,
       RandExpClass: RandExp,
+      unsafeFakerExpressions: getUnsafeFakerExpressions({ validationOptions, schemaState }) === true,
     });
 
     if (!session.isValid()) {

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-controller.js
@@ -12,12 +12,21 @@ function isRecoverableSchemaParseError(error) {
   return error?.code === 'compiler_validation_error';
 }
 
-function parseSchemaTextToRows({ schemaTextToDataRules, schemaText, faker, RandExp, mapRuleToRow, previousRows = [] }) {
+function parseSchemaTextToRows({
+  schemaTextToDataRules,
+  schemaText,
+  faker,
+  RandExp,
+  mapRuleToRow,
+  previousRows = [],
+  unsafeFakerExpressions = false,
+}) {
   const parseResult = parseSchemaText({
     schemaTextToDataRules,
     schemaText,
     faker,
     RandExp,
+    unsafeFakerExpressions,
   });
 
   const tokens = Array.isArray(parseResult.schemaTokens) ? parseResult.schemaTokens : [];
@@ -136,6 +145,7 @@ function createSchemaEditingSession({
   RandExp,
   mapRuleToRow,
   schemaRowsToSpecWithTokens,
+  getUnsafeFakerExpressions = () => false,
   initialRows,
   initialTokens = [],
   initialConstraints = [],
@@ -251,6 +261,7 @@ function createSchemaEditingSession({
       RandExp,
       mapRuleToRow,
       previousRows: state.rows,
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
     });
   }
 

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-editor-core.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-editor-core.js
@@ -104,7 +104,11 @@ function schemaRowsToSpecWithTokens({
   return renderResult.text;
 }
 
-function validateSchemaRows({ schemaRows = [], schemaRowsToDataRules }) {
+function isUnsafeFakerRuleIssue(error) {
+  return error?.reasonCode === 'unsafe_faker_rule';
+}
+
+function validateSchemaRows({ schemaRows = [], schemaRowsToDataRules, unsafeFakerExpressions = false }) {
   const annotatedRows = annotateSchemaRowsWithValidation(schemaRows);
   const result = schemaRowsToDataRules({ schemaRows: annotatedRows });
   const rowErrors = collectSchemaRowValidationErrors(annotatedRows);
@@ -115,7 +119,9 @@ function validateSchemaRows({ schemaRows = [], schemaRowsToDataRules }) {
           candidate?.code === error?.code && candidate?.line === error?.line && candidate?.message === error?.message
       ) === index
   );
-  return { errors: dedupedErrors, rows: annotatedRows };
+  const errors =
+    unsafeFakerExpressions === true ? dedupedErrors.filter((error) => !isUnsafeFakerRuleIssue(error)) : dedupedErrors;
+  return { errors, rows: annotatedRows };
 }
 
 export {

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-error-text.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-error-text.js
@@ -3,15 +3,25 @@
  * - Normalizes schema/parser error collections into user-readable text.
  */
 
+const UNSAFE_FAKER_UI_HINT = "Configure in Test Data Settings 'allow unsafe faker'.";
+
+function appendUnsafeFakerUiHint(message, reasonCode) {
+  const text = String(message ?? '');
+  if (reasonCode !== 'unsafe_faker_rule' || text.includes(UNSAFE_FAKER_UI_HINT)) {
+    return text;
+  }
+  return `${text}. ${UNSAFE_FAKER_UI_HINT}`;
+}
+
 function schemaErrorsToText(errors = []) {
   return (Array.isArray(errors) ? errors : [])
     .map((error) => {
       if (error && typeof error === 'object' && typeof error.message === 'string') {
-        return error.message;
+        return appendUnsafeFakerUiHint(error.message, error.reasonCode);
       }
       return String(error ?? '');
     })
     .join('\n');
 }
 
-export { schemaErrorsToText };
+export { UNSAFE_FAKER_UI_HINT, appendUnsafeFakerUiHint, schemaErrorsToText };

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-row-validation.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-row-validation.js
@@ -12,6 +12,7 @@ import {
 import { Faker } from '@faker-js/faker';
 import { getKnownFakerCommandsAlphabetical, isForbiddenFakerCommand } from '../../faker-commands.js';
 import { getKnownDomainCommandsAlphabetical } from '../../domain-commands.js';
+import { appendUnsafeFakerUiHint } from './schema-error-text.js';
 
 const KNOWN_FAKER_COMMANDS = new Set(
   getKnownFakerCommandsAlphabetical().map((command) => normaliseFakerCommand(command))
@@ -68,7 +69,7 @@ function isBlankSchemaRow(row) {
   );
 }
 
-function createSemanticValidationMessage(row, errorMessage, rowIndex) {
+function createSemanticValidationMessage(row, errorMessage, rowIndex, reasonCode) {
   const rowNumber = rowIndex + 1;
   const sourceType = normaliseSourceType(row?.sourceType);
   const name = String(row?.name ?? '').trim();
@@ -95,9 +96,9 @@ function createSemanticValidationMessage(row, errorMessage, rowIndex) {
   }
 
   if (sourceType === SOURCE_TYPE_DOMAIN || sourceType === SOURCE_TYPE_FAKER) {
-    return `Row ${rowNumber}: invalid ${sourceType} params - ${detail}`;
+    return appendUnsafeFakerUiHint(`Row ${rowNumber}: invalid ${sourceType} params - ${detail}`, reasonCode);
   }
-  return `Row ${rowNumber}: invalid ${sourceType} value - ${detail}`;
+  return appendUnsafeFakerUiHint(`Row ${rowNumber}: invalid ${sourceType} value - ${detail}`, reasonCode);
 }
 
 function getSemanticValidationField(row) {
@@ -336,7 +337,7 @@ function getSchemaRowSemanticValidationIssues(
         rowIndex,
         code: error?.code || 'semantic_validation_failed',
         field,
-        message: createSemanticValidationMessage(row, error?.message, rowIndex),
+        message: createSemanticValidationMessage(row, error?.message, rowIndex, error?.reasonCode),
         severity: getSemanticValidationSeverity(error),
         reasonCode: error?.reasonCode,
       })

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-row-validation.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-row-validation.js
@@ -286,7 +286,7 @@ function getStaticSchemaRowValidationIssues(row, rowIndex) {
 function getSchemaRowSemanticValidationIssues(
   row,
   rowIndex,
-  { schemaTextToDataRules, faker, RandExp, includeBracketGuidance = true } = {}
+  { schemaTextToDataRules, faker, RandExp, includeBracketGuidance = true, unsafeFakerExpressions = false } = {}
 ) {
   if (isBlankSchemaRow(row)) {
     return [];
@@ -319,6 +319,9 @@ function getSchemaRowSemanticValidationIssues(
     schemaText: `${name}\n${ruleSpec}`,
     faker: validationFaker,
     RandExp,
+    options: {
+      unsafeFakerExpressions: unsafeFakerExpressions === true,
+    },
     includeInvalidRules: true,
   });
   const errors = Array.isArray(result?.errors) ? result.errors : [];

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-runtime.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-runtime.js
@@ -6,11 +6,14 @@
 
 import { EnumParser } from '@anywaydata/core/data_generation/utils/enumParser.js';
 
-function parseSchemaText({ schemaTextToDataRules, schemaText, faker, RandExp }) {
+function parseSchemaText({ schemaTextToDataRules, schemaText, faker, RandExp, unsafeFakerExpressions = false }) {
   return schemaTextToDataRules({
     schemaText: String(schemaText ?? ''),
     faker,
     RandExp,
+    options: {
+      unsafeFakerExpressions: unsafeFakerExpressions === true,
+    },
     includeInvalidRules: true,
   });
 }

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
@@ -67,6 +67,7 @@ function createSharedSchemaEditorController({
   onRowsChanged,
   onSchemaTextChanged,
   validateSchemaRows,
+  getUnsafeFakerExpressions = () => false,
   updatePairwiseButtonVisibility = () => {},
   updateHelpHints,
   elements = {},
@@ -100,6 +101,7 @@ function createSharedSchemaEditorController({
         buildDataRuleFromSchemaRow,
         dataRulesToSchemaText,
       }),
+    getUnsafeFakerExpressions,
   });
   const getElementByRole = (role) => rootElement?.querySelector?.(`[data-role="${role}"]`);
   const getRowsElement = () => elements.rowsElement || getElementByRole(SCHEMA_ROWS_ROLE);
@@ -226,6 +228,7 @@ function createSharedSchemaEditorController({
       faker,
       RandExp,
       includeBracketGuidance: false,
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
     })
       .map((issue) => ({
         message: issue?.message,
@@ -238,7 +241,9 @@ function createSharedSchemaEditorController({
     if (typeof validateSchemaRows !== 'function') {
       return { rows: session.getRows(), errors: [] };
     }
-    const validation = validateSchemaRows(session.getRows());
+    const validation = validateSchemaRows(session.getRows(), {
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
+    });
     if (Array.isArray(validation?.rows) && validation.rows.length > 0) {
       session.setRows(validation.rows);
     }
@@ -276,6 +281,7 @@ function createSharedSchemaEditorController({
       schemaTextToDataRules,
       faker,
       RandExp,
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
     });
     session.updateRowAtIndex(rowIndex, (row) => ({
       ...row,
@@ -296,6 +302,7 @@ function createSharedSchemaEditorController({
         schemaTextToDataRules,
         faker,
         RandExp,
+        unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
       }),
     }));
     session.setRows(nextRows);
@@ -497,6 +504,7 @@ function createSharedSchemaEditorController({
       faker,
       RandExp,
       previousRows: session.getRows(),
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
       mapRuleToRow: (rule, leadingTextLines = []) => {
         const mapped =
           typeof mapRuleToRow === 'function' ? mapRuleToRow(rule, leadingTextLines) : createBlankRow(leadingTextLines);
@@ -558,6 +566,7 @@ function createSharedSchemaEditorController({
       faker,
       RandExp,
       previousRows: session.getRows(),
+      unsafeFakerExpressions: getUnsafeFakerExpressions() === true,
       mapRuleToRow: (rule, leadingTextLines = []) => {
         const mapped =
           typeof mapRuleToRow === 'function' ? mapRuleToRow(rule, leadingTextLines) : createBlankRow(leadingTextLines);

--- a/packages/core-ui/src/tests/app/data-population-panel.test.js
+++ b/packages/core-ui/src/tests/app/data-population-panel.test.js
@@ -102,6 +102,7 @@ describe('DataPopulationPanel', () => {
     const generatePairwiseWrapper = panelRoot.querySelector('[data-role="generate-pairwise-button-wrapper"]');
     const generateSchemaButton = panelQueries.getByRole('button', { name: /^grid to enum schema$/i });
     const rowCountInput = panelQueries.getByRole('spinbutton', { name: 'How Many?' });
+    const generationSettingsButton = panelQueries.getByRole('button', { name: 'Generation settings' });
 
     expect(panelRoot).not.toBeNull();
     expect(panelRoot?.classList.contains('testDataSchemaGui')).toBe(true);
@@ -114,7 +115,12 @@ describe('DataPopulationPanel', () => {
     expect(document.getElementById('populationActionsRoot')).toBeNull();
     expect(document.getElementById('generateCountControl')).toBeNull();
     expect(document.getElementById('populationModeSelectorRoot')).toBeNull();
-    expect(panelRoot.querySelectorAll('[data-help-role="help-icon"]')).toHaveLength(3);
+    expect(panelRoot.querySelectorAll('[data-help-role="help-icon"]')).toHaveLength(4);
+    expect(generationSettingsButton.getAttribute('aria-expanded')).toBe('false');
+    generationSettingsButton.click();
+    const riskyFakerCheckbox = panelQueries.getByRole('checkbox', { name: 'allow risky faker' });
+    expect(riskyFakerCheckbox.checked).toBe(true);
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
 
     component.setPairwiseVisible(true);
     expect(generatePairwiseWrapper.style.display).toBe('inline-flex');
@@ -135,6 +141,10 @@ describe('DataPopulationPanel', () => {
     expect(onGenerate).toHaveBeenCalled();
     generateSchemaButton.click();
     expect(onGenerateSchemaFromGrid).toHaveBeenCalled();
+
+    riskyFakerCheckbox.checked = false;
+    riskyFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(component.getUnsafeFakerExpressions()).toBe(false);
 
     const amendSelected = document.querySelector('input[name="testDataGenerationMode"][value="amend-selected"]');
     amendSelected.checked = true;

--- a/packages/core-ui/src/tests/app/data-population-panel.test.js
+++ b/packages/core-ui/src/tests/app/data-population-panel.test.js
@@ -118,9 +118,9 @@ describe('DataPopulationPanel', () => {
     expect(panelRoot.querySelectorAll('[data-help-role="help-icon"]')).toHaveLength(4);
     expect(generationSettingsButton.getAttribute('aria-expanded')).toBe('false');
     generationSettingsButton.click();
-    const riskyFakerCheckbox = panelQueries.getByRole('checkbox', { name: 'allow risky faker' });
-    expect(riskyFakerCheckbox.checked).toBe(true);
-    expect(component.getUnsafeFakerExpressions()).toBe(true);
+    const unsafeFakerCheckbox = panelQueries.getByRole('checkbox', { name: 'allow unsafe faker' });
+    expect(unsafeFakerCheckbox.checked).toBe(false);
+    expect(component.getUnsafeFakerExpressions()).toBe(false);
 
     component.setPairwiseVisible(true);
     expect(generatePairwiseWrapper.style.display).toBe('inline-flex');
@@ -142,9 +142,9 @@ describe('DataPopulationPanel', () => {
     generateSchemaButton.click();
     expect(onGenerateSchemaFromGrid).toHaveBeenCalled();
 
-    riskyFakerCheckbox.checked = false;
-    riskyFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(component.getUnsafeFakerExpressions()).toBe(false);
+    unsafeFakerCheckbox.checked = true;
+    unsafeFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
 
     const amendSelected = document.querySelector('input[name="testDataGenerationMode"][value="amend-selected"]');
     amendSelected.checked = true;

--- a/packages/core-ui/src/tests/app/population-actions.test.js
+++ b/packages/core-ui/src/tests/app/population-actions.test.js
@@ -137,7 +137,8 @@ describe('PopulationActions', () => {
     expect(settingsButton.getAttribute('aria-expanded')).toBe('true');
     expect(settingsDialog.hidden).toBe(false);
     expect(optionHelp.getAttribute('data-help-text')).toContain('helpers.mustache');
-    expect(optionHelp.getAttribute('data-help-text')).toContain('/docs/test-data/faker/helpers');
+    expect(optionHelp.getAttribute('data-help-text')).toContain('https://anywaydata.com/docs/test-data/faker/helpers');
+    expect(optionHelp.getAttribute('data-help-text')).not.toContain('href="/docs/test-data/faker/helpers"');
     expect(checkbox.checked).toBe(false);
     expect(component.getUnsafeFakerExpressions()).toBe(false);
 

--- a/packages/core-ui/src/tests/app/population-actions.test.js
+++ b/packages/core-ui/src/tests/app/population-actions.test.js
@@ -106,6 +106,71 @@ describe('PopulationActions', () => {
     component.destroy();
   });
 
+  test('opens generation settings, updates the browser risky faker option, and closes on outside click', () => {
+    const onUnsafeFakerExpressionsChange = jest.fn();
+    const onGenerate = jest.fn();
+
+    const component = createPopulationActionsComponent({
+      root: document.getElementById('root'),
+      props: {
+        unsafeFakerExpressionsVisible: true,
+        unsafeFakerExpressions: true,
+      },
+      callbacks: {
+        onGenerate,
+        onUnsafeFakerExpressionsChange,
+      },
+    });
+
+    const settingsButton = document.querySelector('[data-role="generation-settings-button"]');
+    const settingsDialog = document.querySelector('[data-role="generation-settings-dialog"]');
+
+    expect(settingsButton).not.toBeNull();
+    expect(settingsButton.getAttribute('aria-expanded')).toBe('false');
+    expect(settingsDialog.hidden).toBe(true);
+
+    settingsButton.click();
+
+    const checkbox = document.querySelector('[data-role="unsafe-faker-expressions-checkbox"]');
+    const optionHelp = settingsDialog.querySelector('[data-help-role="help-icon"]');
+
+    expect(checkbox).not.toBeNull();
+    expect(settingsButton.getAttribute('aria-expanded')).toBe('true');
+    expect(settingsDialog.hidden).toBe(false);
+    expect(optionHelp.getAttribute('data-help-text')).toContain('helpers.mustache');
+    expect(optionHelp.getAttribute('data-help-text')).toContain('/docs/test-data/faker/helpers');
+    expect(checkbox.checked).toBe(true);
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(onUnsafeFakerExpressionsChange).toHaveBeenCalledWith(false);
+    expect(component.getUnsafeFakerExpressions()).toBe(false);
+
+    component.setUnsafeFakerExpressions(true);
+    expect(checkbox.checked).toBe(true);
+
+    document.querySelector('[data-role="generation-settings-close"]').click();
+    expect(settingsDialog.hidden).toBe(true);
+    expect(settingsButton.getAttribute('aria-expanded')).toBe('false');
+
+    settingsButton.click();
+    expect(settingsDialog.hidden).toBe(false);
+    document.body.click();
+    expect(settingsDialog.hidden).toBe(true);
+    expect(settingsButton.getAttribute('aria-expanded')).toBe('false');
+
+    settingsButton.click();
+    expect(settingsDialog.hidden).toBe(false);
+    document.querySelector('[data-role="generate-button"]').click();
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(settingsDialog.hidden).toBe(true);
+    expect(settingsButton.getAttribute('aria-expanded')).toBe('false');
+
+    component.destroy();
+  });
+
   test('supports two instances in one document with distinct ids', () => {
     const onGenerateA = jest.fn();
     const onGenerateB = jest.fn();

--- a/packages/core-ui/src/tests/app/population-actions.test.js
+++ b/packages/core-ui/src/tests/app/population-actions.test.js
@@ -106,7 +106,7 @@ describe('PopulationActions', () => {
     component.destroy();
   });
 
-  test('opens generation settings, updates the browser risky faker option, and closes on outside click', () => {
+  test('opens generation settings, updates the browser unsafe faker option, and closes on outside click', () => {
     const onUnsafeFakerExpressionsChange = jest.fn();
     const onGenerate = jest.fn();
 
@@ -114,7 +114,6 @@ describe('PopulationActions', () => {
       root: document.getElementById('root'),
       props: {
         unsafeFakerExpressionsVisible: true,
-        unsafeFakerExpressions: true,
       },
       callbacks: {
         onGenerate,
@@ -139,17 +138,17 @@ describe('PopulationActions', () => {
     expect(settingsDialog.hidden).toBe(false);
     expect(optionHelp.getAttribute('data-help-text')).toContain('helpers.mustache');
     expect(optionHelp.getAttribute('data-help-text')).toContain('/docs/test-data/faker/helpers');
-    expect(checkbox.checked).toBe(true);
-    expect(component.getUnsafeFakerExpressions()).toBe(true);
-
-    checkbox.checked = false;
-    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-
-    expect(onUnsafeFakerExpressionsChange).toHaveBeenCalledWith(false);
+    expect(checkbox.checked).toBe(false);
     expect(component.getUnsafeFakerExpressions()).toBe(false);
 
-    component.setUnsafeFakerExpressions(true);
-    expect(checkbox.checked).toBe(true);
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(onUnsafeFakerExpressionsChange).toHaveBeenCalledWith(true);
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
+
+    component.setUnsafeFakerExpressions(false);
+    expect(checkbox.checked).toBe(false);
 
     document.querySelector('[data-role="generation-settings-close"]').click();
     expect(settingsDialog.hidden).toBe(true);

--- a/packages/core-ui/src/tests/app/population-actions.test.js
+++ b/packages/core-ui/src/tests/app/population-actions.test.js
@@ -170,6 +170,30 @@ describe('PopulationActions', () => {
     component.destroy();
   });
 
+  test('can show and hide generation settings after mount', () => {
+    const component = createPopulationActionsComponent({
+      root: document.getElementById('root'),
+      props: {
+        unsafeFakerExpressionsVisible: false,
+      },
+    });
+
+    expect(document.querySelector('[data-role="generation-settings-button"]')).toBeNull();
+
+    component.update({ unsafeFakerExpressionsVisible: true });
+    const settingsButton = document.querySelector('[data-role="generation-settings-button"]');
+    expect(settingsButton).not.toBeNull();
+
+    settingsButton.click();
+    expect(document.querySelector('[data-role="generation-settings-dialog"]').hidden).toBe(false);
+
+    component.update({ unsafeFakerExpressionsVisible: false });
+    expect(document.querySelector('[data-role="generation-settings-button"]')).toBeNull();
+    expect(document.querySelector('[data-role="generation-settings-dialog"]')).toBeNull();
+
+    component.destroy();
+  });
+
   test('supports two instances in one document with distinct ids', () => {
     const onGenerateA = jest.fn();
     const onGenerateB = jest.fn();

--- a/packages/core-ui/src/tests/app/test-data-population-toolbar.test.js
+++ b/packages/core-ui/src/tests/app/test-data-population-toolbar.test.js
@@ -63,12 +63,18 @@ describe('TestDataPopulationToolbar', () => {
     const generateButton = toolbarQueries.getByRole('button', { name: /^generate$/i });
     const generateSchemaButton = toolbarQueries.getByRole('button', { name: /^grid to enum schema$/i });
     const rowCountInput = toolbarQueries.getByRole('spinbutton', { name: 'How Many?' });
+    const generationSettingsButton = toolbarQueries.getByRole('button', { name: 'Generation settings' });
     const generatePairwiseWrapper = toolbarRoot.querySelector('[data-role="generate-pairwise-button-wrapper"]');
 
     expect(toolbarRoot).not.toBeNull();
     expect(toolbarRoot.classList.contains('data-population-toolbar')).toBe(true);
     expect(generatePairwiseWrapper.style.display).toBe('none');
     expect(toolbarQueries.getByRole('radio', { name: 'New Table' }).checked).toBe(true);
+    expect(generationSettingsButton.getAttribute('aria-expanded')).toBe('false');
+    generationSettingsButton.click();
+    const riskyFakerCheckbox = toolbarQueries.getByRole('checkbox', { name: 'allow risky faker' });
+    expect(riskyFakerCheckbox.checked).toBe(true);
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
 
     component.setPairwiseVisible(true);
     expect(generatePairwiseWrapper.style.display).toBe('inline-flex');
@@ -93,6 +99,10 @@ describe('TestDataPopulationToolbar', () => {
     generateSchemaButton.click();
     expect(onGenerate).toHaveBeenCalled();
     expect(onGenerateSchemaFromGrid).toHaveBeenCalled();
+
+    riskyFakerCheckbox.checked = false;
+    riskyFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(component.getUnsafeFakerExpressions()).toBe(false);
 
     const amendSelected = toolbarQueries.getByRole('radio', { name: 'Amend Selected' });
     amendSelected.checked = true;

--- a/packages/core-ui/src/tests/app/test-data-population-toolbar.test.js
+++ b/packages/core-ui/src/tests/app/test-data-population-toolbar.test.js
@@ -72,9 +72,9 @@ describe('TestDataPopulationToolbar', () => {
     expect(toolbarQueries.getByRole('radio', { name: 'New Table' }).checked).toBe(true);
     expect(generationSettingsButton.getAttribute('aria-expanded')).toBe('false');
     generationSettingsButton.click();
-    const riskyFakerCheckbox = toolbarQueries.getByRole('checkbox', { name: 'allow risky faker' });
-    expect(riskyFakerCheckbox.checked).toBe(true);
-    expect(component.getUnsafeFakerExpressions()).toBe(true);
+    const unsafeFakerCheckbox = toolbarQueries.getByRole('checkbox', { name: 'allow unsafe faker' });
+    expect(unsafeFakerCheckbox.checked).toBe(false);
+    expect(component.getUnsafeFakerExpressions()).toBe(false);
 
     component.setPairwiseVisible(true);
     expect(generatePairwiseWrapper.style.display).toBe('inline-flex');
@@ -100,9 +100,9 @@ describe('TestDataPopulationToolbar', () => {
     expect(onGenerate).toHaveBeenCalled();
     expect(onGenerateSchemaFromGrid).toHaveBeenCalled();
 
-    riskyFakerCheckbox.checked = false;
-    riskyFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(component.getUnsafeFakerExpressions()).toBe(false);
+    unsafeFakerCheckbox.checked = true;
+    unsafeFakerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(component.getUnsafeFakerExpressions()).toBe(true);
 
     const amendSelected = toolbarQueries.getByRole('radio', { name: 'Amend Selected' });
     amendSelected.checked = true;

--- a/packages/core-ui/src/tests/grid/generation/test-data-generation-service.test.js
+++ b/packages/core-ui/src/tests/grid/generation/test-data-generation-service.test.js
@@ -269,6 +269,157 @@ describe('test-data-generation-service', () => {
     );
   });
 
+  test('generateTestData passes the browser unsafe faker setting into generation sessions', async () => {
+    const createGenerationSessionFn = jest.fn(() => ({
+      isValid: () => true,
+      getErrors: () => [],
+      generateRows: async () => ({
+        ok: true,
+        headers: ['Sentence'],
+        rows: [['I found 1 instances.']],
+        diagnostics: { rowCount: 1 },
+      }),
+    }));
+
+    const service = createTestDataGenerationService({
+      schemaTextToDataRules: jest.fn(),
+      TestDataGeneratorClass: class {},
+      PairwiseTestDataGeneratorClass: class {},
+      GenericDataTableClass: class FakeGenericDataTable {
+        constructor() {
+          this.headers = [];
+          this.rows = [];
+        }
+        setHeaders(headers) {
+          this.headers = headers;
+        }
+        appendDataRow(row) {
+          this.rows.push(row);
+        }
+      },
+      TEST_DATA_MODES: {
+        NEW_TABLE: 'new-table',
+        AMEND_TABLE: 'amend-table',
+        AMEND_SELECTED: 'amend-selected',
+      },
+      normaliseCount: () => 1,
+      createTableFromGenerator: jest.fn(),
+      createAmendedTable: jest.fn(),
+      schemaRowsToSpec: jest.fn(() => 'Sentence\nhelpers.mustache("x", { count: () => `${this.number.int()}` })'),
+      faker: {},
+      RandExp: function RandExp() {},
+      debouncer: { clear: jest.fn() },
+      syncSchemaTextFromGridBeforeGenerate: jest.fn(),
+      getSchemaText: () => '',
+      setTestDataStatus: jest.fn(),
+      setTestDataLoadingStatus: jest.fn(),
+      showSchemaError: jest.fn(),
+      yieldToUi: jest.fn(() => Promise.resolve()),
+      validateCurrentSchemaRows: jest.fn(() => ({
+        errors: [],
+        rows: [
+          {
+            name: 'Sentence',
+            sourceType: 'faker',
+            command: 'helpers.mustache',
+            params: '("x", { count: () => `${this.number.int()}` })',
+          },
+        ],
+      })),
+      getImporter: () => ({ setGridFromGenericDataTable: jest.fn() }),
+      getTextPreviewRenderer: jest.fn(),
+      getMainGridExtras: jest.fn(),
+      getGenerationMode: () => 'new-table',
+      getRequestedRowCount: () => 1,
+      getUnsafeFakerExpressions: () => false,
+      createGenerationSessionFn,
+    });
+
+    await service.generateTestData();
+
+    expect(createGenerationSessionFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unsafeFakerExpressions: false,
+      })
+    );
+  });
+
+  test('direct amend generator creation receives the browser unsafe faker setting', async () => {
+    const generatorOptions = [];
+    const gridExtras = {
+      applyGeneratedSchemaAmend: jest.fn(() => ({ amendedRowCount: 1 })),
+    };
+
+    const service = createTestDataGenerationService({
+      schemaTextToDataRules: jest.fn(),
+      TestDataGeneratorClass: class FakeGenerator {
+        constructor(_faker, _RandExp, options) {
+          generatorOptions.push(options);
+          this.compiler = { validate: jest.fn() };
+          this.rulesParser = { testDataRules: { rules: [{ name: 'Sentence' }] } };
+        }
+        importSpec() {}
+        compile() {}
+        testDataRules() {
+          return [{ name: 'Sentence' }];
+        }
+        isValid() {
+          return true;
+        }
+        errors() {
+          return [];
+        }
+        generateHeadersArray() {
+          return ['Sentence'];
+        }
+        generateRow() {
+          return ['I found 1 instances.'];
+        }
+      },
+      PairwiseTestDataGeneratorClass: class {},
+      GenericDataTableClass: class {},
+      TEST_DATA_MODES: {
+        NEW_TABLE: 'new-table',
+        AMEND_TABLE: 'amend-table',
+        AMEND_SELECTED: 'amend-selected',
+      },
+      normaliseCount: () => 1,
+      createTableFromGenerator: jest.fn(),
+      createAmendedTable: jest.fn(),
+      schemaRowsToSpec: jest.fn(() => 'Sentence\nhelpers.mustache("x", { count: () => `${this.number.int()}` })'),
+      faker: {},
+      RandExp: function RandExp() {},
+      debouncer: { clear: jest.fn() },
+      syncSchemaTextFromGridBeforeGenerate: jest.fn(),
+      setTestDataStatus: jest.fn(),
+      setTestDataLoadingStatus: jest.fn(),
+      showSchemaError: jest.fn(),
+      yieldToUi: jest.fn(() => Promise.resolve()),
+      validateCurrentSchemaRows: jest.fn(() => ({
+        errors: [],
+        rows: [
+          {
+            name: 'Sentence',
+            sourceType: 'faker',
+            command: 'helpers.mustache',
+            params: '("x", { count: () => `${this.number.int()}` })',
+          },
+        ],
+      })),
+      getImporter: () => ({ setGridFromGenericDataTable: jest.fn() }),
+      getTextPreviewRenderer: jest.fn(),
+      getMainGridExtras: () => gridExtras,
+      getGenerationMode: () => 'amend-table',
+      getRequestedRowCount: () => 1,
+      getUnsafeFakerExpressions: () => false,
+    });
+
+    await service.generateTestData();
+
+    expect(generatorOptions[0]).toEqual({ unsafeFakerExpressions: false });
+    expect(gridExtras.applyGeneratedSchemaAmend).toHaveBeenCalled();
+  });
+
   test('generatePairwiseTestData validates schema rows once before creating the generator', async () => {
     const validateCurrentSchemaRows = jest.fn(() => ({
       errors: [],

--- a/packages/core-ui/src/tests/shared/schema-controller.test.js
+++ b/packages/core-ui/src/tests/shared/schema-controller.test.js
@@ -105,6 +105,31 @@ describe('schema-controller', () => {
     ]);
   });
 
+  test('parseSchemaTextToRows passes the unsafe faker opt-in to the parser', () => {
+    const parser = jest.fn().mockReturnValue({
+      dataRules: [{ name: 'Name', ruleSpec: 'helpers.mustache("Hello {{name}}", { name: () => "Ada" })' }],
+      errors: [],
+      schemaTokens: [{ kind: 'rule' }],
+    });
+
+    parseSchemaTextToRows({
+      schemaTextToDataRules: parser,
+      schemaText: 'Name\nhelpers.mustache("Hello {{name}}", { name: () => "Ada" })',
+      faker: {},
+      RandExp: function RandExp() {},
+      unsafeFakerExpressions: true,
+      mapRuleToRow: (rule) => ({ name: rule.name, value: rule.ruleSpec }),
+    });
+
+    expect(parser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          unsafeFakerExpressions: true,
+        },
+      })
+    );
+  });
+
   test('row mutation helpers add remove and move rows immutably', () => {
     const blank = () => ({ name: '', sourceType: 'regex', value: '' });
     const baseRows = [{ name: 'A' }, { name: 'B' }];
@@ -268,5 +293,39 @@ describe('schema-controller', () => {
     expect(toggleResult.ok).toBe(false);
     expect(session.getTextMode()).toBe(true);
     expect(session.getRows()).toEqual([{ name: 'Previous', sourceType: 'literal', value: 'ok' }]);
+  });
+
+  test('schema editing session uses the current unsafe faker setting when syncing text rows', () => {
+    const blank = () => ({
+      name: '',
+      sourceType: 'regex',
+      command: '',
+      params: '',
+      value: '',
+      comments: '',
+    });
+    const schemaTextToDataRules = jest.fn().mockReturnValue({
+      dataRules: [{ name: 'Name', ruleSpec: 'helpers.mustache("Hello {{name}}", { name: () => "Ada" })' }],
+      errors: [],
+      schemaTokens: [{ kind: 'rule' }],
+    });
+    let unsafeFakerExpressions = false;
+    const session = createSchemaEditingSession({
+      createBlankSchemaRow: blank,
+      schemaTextToDataRules,
+      faker: {},
+      RandExp: function RandExp() {},
+      mapRuleToRow: (rule) => ({ name: rule.name, value: rule.ruleSpec }),
+      schemaRowsToSpecWithTokens: jest.fn(() => ''),
+      getUnsafeFakerExpressions: () => unsafeFakerExpressions,
+      initialTextMode: true,
+    });
+
+    session.syncRowsFromText({ schemaText: 'Name\nhelpers.mustache("Hello {{name}}", { name: () => "Ada" })' });
+    unsafeFakerExpressions = true;
+    session.syncRowsFromText({ schemaText: 'Name\nhelpers.mustache("Hello {{name}}", { name: () => "Ada" })' });
+
+    expect(schemaTextToDataRules.mock.calls[0][0].options.unsafeFakerExpressions).toBe(false);
+    expect(schemaTextToDataRules.mock.calls[1][0].options.unsafeFakerExpressions).toBe(true);
   });
 });

--- a/packages/core-ui/src/tests/shared/schema-editor-core.test.js
+++ b/packages/core-ui/src/tests/shared/schema-editor-core.test.js
@@ -1,0 +1,39 @@
+import { validateSchemaRows } from '../../../js/gui_components/shared/test-data/schema/schema-editor-core.js';
+
+describe('schema-editor-core', () => {
+  test('keeps unsafe faker validation warnings blocking until unsafe faker is enabled', () => {
+    const schemaRowsToDataRules = () => ({ dataRules: [], errors: [] });
+    const row = {
+      name: 'Choice',
+      sourceType: 'faker',
+      command: 'helpers.fake',
+      params: '(faker.person.firstName())',
+      semanticValidationIssues: [
+        {
+          code: 'compiler_validation_error',
+          reasonCode: 'unsafe_faker_rule',
+          field: 'params',
+          line: 1,
+          severity: 'warning',
+          message: 'Row 1: invalid faker params - Unsafe faker rule syntax detected',
+        },
+      ],
+    };
+
+    expect(
+      validateSchemaRows({
+        schemaRows: [row],
+        schemaRowsToDataRules,
+        unsafeFakerExpressions: false,
+      }).errors
+    ).toHaveLength(1);
+
+    expect(
+      validateSchemaRows({
+        schemaRows: [row],
+        schemaRowsToDataRules,
+        unsafeFakerExpressions: true,
+      }).errors
+    ).toEqual([]);
+  });
+});

--- a/packages/core-ui/src/tests/shared/schema-error-text.test.js
+++ b/packages/core-ui/src/tests/shared/schema-error-text.test.js
@@ -1,0 +1,23 @@
+import { schemaErrorsToText } from '../../../js/gui_components/shared/test-data/schema/schema-error-text.js';
+
+describe('schema-error-text', () => {
+  test('adds the browser unsafe faker setting hint to unsafe faker schema errors', () => {
+    expect(
+      schemaErrorsToText([
+        {
+          message:
+            'Names failed faker validation - Invalid Faker API Call Unsafe faker rule syntax detected: requires complex argument parsing',
+          reasonCode: 'unsafe_faker_rule',
+        },
+      ])
+    ).toBe(
+      "Names failed faker validation - Invalid Faker API Call Unsafe faker rule syntax detected: requires complex argument parsing. Configure in Test Data Settings 'allow unsafe faker'."
+    );
+  });
+
+  test('does not add the unsafe faker setting hint to unrelated schema errors', () => {
+    expect(schemaErrorsToText([{ message: 'Name failed domain validation - bad params' }])).toBe(
+      'Name failed domain validation - bad params'
+    );
+  });
+});

--- a/packages/core-ui/src/tests/shared/schema-row-validation.test.js
+++ b/packages/core-ui/src/tests/shared/schema-row-validation.test.js
@@ -135,6 +135,7 @@ describe('schema-row-validation', () => {
         message: expect.stringContaining('Unsafe faker rule syntax detected'),
       }),
     ]);
+    expect(issues[0].message).toContain("Configure in Test Data Settings 'allow unsafe faker'.");
   });
 
   test('allows unsafe faker semantic validation when explicitly opted in', () => {

--- a/packages/core-ui/src/tests/shared/schema-row-validation.test.js
+++ b/packages/core-ui/src/tests/shared/schema-row-validation.test.js
@@ -137,6 +137,26 @@ describe('schema-row-validation', () => {
     ]);
   });
 
+  test('allows unsafe faker semantic validation when explicitly opted in', () => {
+    const issues = getSchemaRowSemanticValidationIssues(
+      {
+        name: 'Choice',
+        sourceType: 'faker',
+        command: 'helpers.fake',
+        params: '(faker.person.firstName())',
+      },
+      0,
+      {
+        schemaTextToDataRules,
+        faker,
+        RandExp,
+        unsafeFakerExpressions: true,
+      }
+    );
+
+    expect(issues).toEqual([]);
+  });
+
   test('reports malformed helpers.arrayElement params with array guidance', () => {
     const issues = getSchemaRowSemanticValidationIssues(
       {

--- a/packages/core-ui/src/tests/shared/ui-generation-session-service.test.js
+++ b/packages/core-ui/src/tests/shared/ui-generation-session-service.test.js
@@ -57,8 +57,41 @@ describe('ui-generation-session-service', () => {
     expect(createGenerationSessionFn).toHaveBeenCalledWith(
       expect.objectContaining({
         textSpec: 'Status\nenum(open,closed)\n\nIF [Status] = "open" THEN [Status] = "closed" ENDIF',
+        unsafeFakerExpressions: true,
       })
     );
+  });
+
+  test('createSessionContext passes the current unsafe faker setting into generation sessions', () => {
+    const createGenerationSessionFn = jest.fn(() => ({
+      isValid: () => true,
+      getErrors: () => [],
+      diagnostics: {},
+    }));
+    let unsafeFakerExpressions = false;
+
+    const service = createUiGenerationSessionService({
+      getValidatedSchemaState: () => ({
+        errors: [],
+        rows: [{ name: 'Sentence', sourceType: 'faker', command: 'helpers.mustache', params: '("x")' }],
+      }),
+      getSchemaText: () => '',
+      schemaRowsToSpec: () => 'Sentence\nhelpers.mustache("x")',
+      schemaSource: 'test',
+      GenericDataTableClass: FakeGenericDataTable,
+      CombinationsTestDataGeneratorClass: class {},
+      createGenerationSessionFn,
+      getUnsafeFakerExpressions: () => unsafeFakerExpressions,
+      faker: {},
+      RandExp: function RandExp() {},
+    });
+
+    service.createSessionContext();
+    unsafeFakerExpressions = true;
+    service.createSessionContext();
+
+    expect(createGenerationSessionFn.mock.calls[0][0].unsafeFakerExpressions).toBe(false);
+    expect(createGenerationSessionFn.mock.calls[1][0].unsafeFakerExpressions).toBe(true);
   });
 
   test('counts domain datatype.enum rows as enum-capable', () => {

--- a/packages/core-ui/src/tests/shared/ui-generation-session-service.test.js
+++ b/packages/core-ui/src/tests/shared/ui-generation-session-service.test.js
@@ -57,7 +57,7 @@ describe('ui-generation-session-service', () => {
     expect(createGenerationSessionFn).toHaveBeenCalledWith(
       expect.objectContaining({
         textSpec: 'Status\nenum(open,closed)\n\nIF [Status] = "open" THEN [Status] = "closed" ENDIF',
-        unsafeFakerExpressions: true,
+        unsafeFakerExpressions: false,
       })
     );
   });

--- a/packages/core/js/mcp/anywaydata-mcp-contract.js
+++ b/packages/core/js/mcp/anywaydata-mcp-contract.js
@@ -230,6 +230,12 @@ function createGenerateDataTool() {
           type: 'boolean',
           description: 'Generate pairwise combinations for ENUM fields (requires at least 2 ENUM rules).',
         },
+        unsafeFakerExpressions: {
+          type: 'boolean',
+          default: false,
+          description:
+            'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
+        },
       },
       required: ['textSpec', 'rowCount', 'outputFormat'],
     },
@@ -268,6 +274,12 @@ function createAmendDataTool() {
         stream: {
           type: 'boolean',
           description: 'Accepted for compatibility and ignored for amend operation (always buffered).',
+        },
+        unsafeFakerExpressions: {
+          type: 'boolean',
+          default: false,
+          description:
+            'Allow expression-style faker arguments such as callbacks in helpers.* commands. Unsafe for untrusted input.',
         },
       },
       required: ['textSpec', 'inputData', 'inputFormat', 'outputFormat'],
@@ -342,11 +354,12 @@ function executeGenerateOrAmendTool(toolName, args = {}) {
     return textSpecLengthError;
   }
 
+  const unsafeFakerExpressions = normalizedArgs.unsafeFakerExpressions === true;
   const safeSession = createGenerationSession({
     textSpec: normalizedArgs.textSpec,
     seed: normalizedArgs.seed,
-    unsafeFakerExpressions: false,
-    safeFakerRules: true,
+    unsafeFakerExpressions,
+    safeFakerRules: !unsafeFakerExpressions,
     schemaSource: 'mcp',
   });
 
@@ -359,7 +372,8 @@ function executeGenerateOrAmendTool(toolName, args = {}) {
     : toolName === 'amend_data_from_spec'
       ? amendFromTextSpecAndData({
           ...normalizedArgs,
-          safeFakerRules: true,
+          unsafeFakerExpressions,
+          safeFakerRules: !unsafeFakerExpressions,
         })
       : normalizedArgs.pairwise
         ? safeSession.generatePairwise({

--- a/packages/core/src/tests/mcp/anywaydata-mcp-contract.test.js
+++ b/packages/core/src/tests/mcp/anywaydata-mcp-contract.test.js
@@ -54,6 +54,18 @@ describe('AnyWayData MCP contract', () => {
     });
   });
 
+  test('allows unsafe faker expressions when explicitly requested', () => {
+    const result = executeAnyWayDataMcpTool('generate_data_from_spec', {
+      textSpec: 'Sentence\nhelpers.mustache("Hello {{name}}", { name: () => "Ada" })',
+      rowCount: 1,
+      outputFormat: 'json',
+      unsafeFakerExpressions: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.rows).toEqual([['Hello Ada']]);
+  });
+
   test('preserves session diagnostics for invalid generation specs', () => {
     const result = executeAnyWayDataMcpTool('generate_data_from_spec', {
       textSpec: 'Name',
@@ -79,6 +91,8 @@ describe('AnyWayData MCP contract', () => {
       expect(tool.inputSchema.properties.options.properties).toHaveProperty('delimiter');
       expect(tool.inputSchema.properties.options.properties).not.toHaveProperty('outputFormat');
       expect(tool.inputSchema.properties.options.properties).not.toHaveProperty('options');
+      expect(tool.inputSchema.properties.unsafeFakerExpressions.type).toBe('boolean');
+      expect(tool.inputSchema.properties.unsafeFakerExpressions.description).toContain('helpers.*');
     }
   });
 


### PR DESCRIPTION
## Summary
- adds a Generation settings cog with an `allow risky faker` option for browser generation flows
- keeps risky Faker expression support disabled by default, with explicit opt-ins for UI, CLI, MCP, and API usage
- documents risky helper variants and updates API/OpenAPI and MCP contract coverage
- ignores generated Codex dev web stdout/stderr logs

Closes #245

## Verification
- `pnpm --dir docs-src run build`
- Playwright live check against `http://127.0.0.1:4173/app.html`
- `pnpm run verify:ui`
- `pnpm run verify:local`
- commit hook: format check + full Jest suite
- pre-push hook: local verification gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Generation settings” UI with an **allow unsafe faker expressions** toggle, surfaced in the data generation workflow (including panels, toolbar, and Storybook).
  * Enabled opt-in propagation for unsafe faker expressions through the generation pipeline, including REST and MCP endpoints/tools.
* **Documentation**
  * Expanded guidance on unsafe faker helper variants and the safe opt-in process across Web UI, CLI, REST, and MCP.
* **Tests**
  * Added/updated UI, schema validation, generator, and MCP/integration tests to confirm toggle behavior and unsafe-expression output.
* **Chores**
  * Updated ignore rules for development log artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->