### PR TITLE
Fix generator schema row tab order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ testenv/
 experiments
 experiments/*
 .codex-logs/
-.codex-dev-web.log
+.codex-dev-web*.log

--- a/apps/web/src/tests/browser/generator/functional/schema-edit.spec.js
+++ b/apps/web/src/tests/browser/generator/functional/schema-edit.spec.js
@@ -37,6 +37,35 @@ test.describe('Generator Schema Editing', () => {
     expectNoPageErrors(pageErrors);
   });
 
+  test('tabs through schema row fields before row action buttons', async ({ page }) => {
+    const { generatorPage, pageErrors } = await openGenerator(page);
+
+    await generatorPage.schema.setTextMode(false);
+    const row = generatorPage.schema.row(0);
+    const nameInput = row.locator('input[data-field="name"]');
+    const sourceTypeSelect = row.locator('select[data-field="sourceType"]');
+    const helpLink = row.locator('[data-field="faker-doc-link"]');
+    const valueInput = row.locator('input[data-field="value"]');
+    const dragButton = row.locator('[data-action="drag"]');
+
+    await nameInput.focus();
+    await expect(nameInput).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(sourceTypeSelect).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(helpLink).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(valueInput).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(dragButton).toBeFocused();
+
+    expectNoPageErrors(pageErrors);
+  });
+
   test('can edit as schema then edit as text', async ({ page }) => {
     const { generatorPage, pageErrors } = await openGenerator(page);
 

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -2206,9 +2206,11 @@ body.theme-dark .shared-schema-row-validation {
   }
   .shared-schema-row-actions {
     grid-column: 1 / span 3;
+    grid-row: 1;
   }
   .shared-schema-row > input[data-field='name'] {
     grid-column: 1 / span 3;
+    grid-row: 2;
   }
   .shared-schema-row > select[data-field='sourceType'] {
     grid-column: 1;

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1985,8 +1985,45 @@ body.theme-dark .generator-status-text[data-severity='info'] {
 }
 
 .shared-schema-row-actions {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   gap: 0.2rem;
+}
+
+.shared-schema-row > input[data-field='name'] {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.shared-schema-row > select[data-field='sourceType'] {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.shared-schema-row > .shared-schema-command-picker-control {
+  grid-column: 4;
+  grid-row: 1;
+}
+
+.shared-schema-row-command > .shared-schema-help-link {
+  grid-column: 5;
+  grid-row: 1;
+}
+
+.shared-schema-row-value > .shared-schema-help-link {
+  grid-column: 4;
+  grid-row: 1;
+}
+
+.shared-schema-row > .shared-schema-params-control {
+  grid-column: 6;
+  grid-row: 1;
+}
+
+.shared-schema-row > input[data-field='value'] {
+  grid-column: 5;
+  grid-row: 1;
 }
 
 .shared-schema-drag-handle {

--- a/docs-src/blog/2026-06-12-combinatorial-grid-workflows.md
+++ b/docs-src/blog/2026-06-12-combinatorial-grid-workflows.md
@@ -1,39 +1,17 @@
 slug: combinatorial-grid-workflows
 authors: [alan]
-tags: [release, feature, combinatorial, schema, import, export, ux]
+tags: [release, feature, combinatorial, schema, import, export, ux, faker, api, cli, mcp]
 date: 2026-06-12T10:00
 ---
 
 The next release is centered on one theme: faster paths from existing data to realistic, constrained, exportable test sets.
 
-This release adds broader combinatorial generation, schema authoring improvements, better import/export controls, and a few high-value grid usability upgrades.
+This release adds broader combinatorial generation, schema authoring improvements, safe-by-default Faker helper controls across interfaces, better import/export controls, and a few high-value grid usability upgrades.
 
 <!-- truncate -->
 
-## 1. Auto-increment timestamps for deterministic event streams
 
-You can now generate timestamps that move forward one row at a time instead of relying on purely random dates.
-
-Example:
-
-```text
-CreatedAt
-autoIncrement.timestamp(start="2026-06-12T12:39:23Z", step=1, type="seconds")
-```
-
-That produces:
-
-- row 1: `2026-06-12T12:39:23Z`
-- row 2: `2026-06-12T12:39:24Z`
-- row 3: `2026-06-12T12:39:25Z`
-
-This is useful for audit logs, event streams, ordered API records, and any test data where time should progress predictably across generated rows.
-
-Docs:
-
-- [autoIncrement Domain](/docs/test-data/domain/autoIncrement)
-
-## 2. N-wise combinatorial generation, not just pairwise
+## 1. N-wise combinatorial generation, not just pairwise
 
 The biggest addition is that combinatorial generation now goes beyond pairwise.
 
@@ -63,7 +41,7 @@ Docs:
 
 ![N-wise combinations dialog](/img/release-198/n-wise-generation.png)
 
-## 3. Schema constraints with PICT-style `IF ... THEN ...`
+## 2. Schema constraints with PICT-style `IF ... THEN ...`
 
 Schema constraints make generated combinations more realistic by filtering out invalid rows.
 
@@ -92,7 +70,7 @@ Docs:
 
 - [Schema Definition](/docs/test-data/Schema-Definition)
 
-## 4. Grid to Enum Schema for turning existing tables into generators
+## 3. Grid to Enum Schema for turning existing tables into generators
 
 If you already have representative data in the main grid, you can now turn that grid into an enum schema automatically.
 
@@ -124,32 +102,9 @@ Docs:
 
 ![Grid to enum schema in the app](/img/release-198/grid-to-enum-schema.png)
 
-## 5. Constraint-aware auto-increment sequences for generated identifiers
 
-Schemas can now generate sequential IDs through the domain model with `autoIncrement.sequence`.
 
-Example:
-
-```text
-Filename
-autoIncrement.sequence(start=1, step=5, prefix="filename", suffix=".txt", zeropadding=3)
-```
-
-Generated values:
-
-```text
-filename001.txt
-filename0006.txt
-filename011.txt
-```
-
-This is especially useful for ticket IDs, filenames, and human-readable references because the sequence only advances when a row is accepted. If a generated row is rejected by constraints and retried, the skipped attempt does not consume the next number.
-
-Docs:
-
-- [Auto Increment Sequences](/docs/test-data/auto-increment-sequences)
-
-## 6. PICT-style inline enum definitions such as `Name: values`
+## 4. PICT-style inline enum definitions such as `Name: values`
 
 Schema text now fits more naturally with compact PICT-style authoring.
 
@@ -174,7 +129,8 @@ Docs:
 
 - [Schema Definition](/docs/test-data/Schema-Definition)
 
-## 7. Import trimming controls for cleaner amend and import workflows
+
+## 5. Import trimming controls for cleaner amend and import workflows
 
 Imported files and clipboard data can now be normalized during import.
 
@@ -197,7 +153,7 @@ Docs:
 
 ![Import trim settings](/img/release-198/import-trim-settings.png)
 
-## 8. File export settings for line endings and BOM
+## 6. File export settings for line endings and BOM
 
 Downloads now support file transport settings without changing the preview text shown in the browser.
 
@@ -214,7 +170,7 @@ Docs:
 
 ![Download encoding settings](/img/release-198/export-encoding-settings.png)
 
-## 9. Right-click context menu in the main data grid
+## 7. Right-click context menu in the main data grid
 
 The editable grid now has a right-click context menu for common grid actions.
 
@@ -224,7 +180,7 @@ Docs:
 
 - [Data Grid Editable](/docs/test-data/data-grid-editable)
 
-## 10. Always-visible total row counts in the data grid
+## 8. Always-visible total row counts in the data grid
 
 The main grid now shows total row counts, and filtered views also show how many rows remain visible.
 
@@ -251,7 +207,8 @@ Taken together, these features make the tool better at moving through the whole 
 1. start with imported or hand-edited data
 2. convert it into a schema
 3. add constraints
-4. generate the right amount of combinatorial coverage
-5. export in the format and file encoding you actually need
+4. enable unsafe Faker helper expressions only when the schema is trusted
+5. generate the right amount of combinatorial coverage
+6. export in the format and file encoding you actually need
 
 The release adds more generation power, reduces setup time, and cleanup time around that generation.

--- a/docs-src/blog/2026-06-30-increments-and-helpers.md
+++ b/docs-src/blog/2026-06-30-increments-and-helpers.md
@@ -1,3 +1,4 @@
+---
 slug: auto-increments-helpers
 authors: [alan]
 tags: [release, feature]
@@ -47,7 +48,7 @@ Generated values:
 
 ```text
 filename001.txt
-filename0006.txt
+filename006.txt
 filename011.txt
 ```
 

--- a/docs-src/blog/2026-06-30-increments-and-helpers.md
+++ b/docs-src/blog/2026-06-30-increments-and-helpers.md
@@ -1,0 +1,88 @@
+slug: auto-increments-helpers
+authors: [alan]
+tags: [release, feature]
+date: 2026-06-30T10:00
+---
+
+This release expands the commands available in the domain model, allows more helper functions in the UI and has general UI improvements.
+
+<!-- truncate -->
+
+## 1. Auto-increment timestamps for deterministic event streams
+
+You can now generate timestamps that move forward one row at a time instead of relying on purely random dates.
+
+Example:
+
+```text
+CreatedAt
+autoIncrement.timestamp(start="2026-06-12T12:39:23Z", step=1, type="seconds")
+```
+
+That produces:
+
+- row 1: `2026-06-12T12:39:23Z`
+- row 2: `2026-06-12T12:39:24Z`
+- row 3: `2026-06-12T12:39:25Z`
+
+This is useful for audit logs, event streams, ordered API records, and any test data where time should progress predictably across generated rows.
+
+Docs:
+
+- [autoIncrement Domain](/docs/test-data/domain/autoIncrement)
+
+
+## 2. Constraint-aware auto-increment sequences for generated identifiers
+
+Schemas can now generate sequential IDs through the domain model with `autoIncrement.sequence`.
+
+Example:
+
+```text
+Filename
+autoIncrement.sequence(start=1, step=5, prefix="filename", suffix=".txt", zeropadding=3)
+```
+
+Generated values:
+
+```text
+filename001.txt
+filename0006.txt
+filename011.txt
+```
+
+This is especially useful for ticket IDs, filenames, and human-readable references because the sequence only advances when a row is accepted. If a generated row is rejected by constraints and retried, the skipped attempt does not consume the next number.
+
+Docs:
+
+- [Auto Increment Sequences](/docs/test-data/auto-increment-sequences)
+
+## 3. Allow unsafe Faker helpers from the UI when you trust the schema
+
+Faker helper commands stay safe by default. Simple literal helper calls continue to work normally, but expression-style helper arguments that execute callback-shaped schema text require an explicit opt-in.
+
+That opt-in is now available in the Web UI as **allow unsafe faker** in the Test Data Settings dialog behind the cog.
+
+Example unsafe helper:
+
+```text
+Names
+helpers.multiple(() => this.person.firstName(), { count: 3 })
+```
+
+Use this only for schemas you trust. The browser setting now matches the other integration surfaces:
+
+- Web UI: enable **allow unsafe faker** from the Test Data Settings cog.
+- REST API: pass `unsafeFakerExpressions: true` in supported generation request bodies.
+- CLI: pass `--unsafe-faker-expressions`.
+- MCP: pass `unsafeFakerExpressions: true` in the generation tool arguments.
+
+Docs:
+
+- [Faker Helpers](/docs/test-data/faker/helpers)
+- [Web UI](/docs/interfaces-and-deployment/web-ui)
+- [REST API](/docs/interfaces-and-deployment/rest-api)
+- [MCP](/docs/interfaces-and-deployment/mcp)
+- [CLI](/docs/interfaces-and-deployment/cli-node-and-bun)
+
+

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/schema-focus-state.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/schema-focus-state.js
@@ -5,7 +5,7 @@ function captureActiveFieldState(documentObj) {
   const fieldName = activeElement?.getAttribute?.('data-field');
   const actionName = activeElement?.getAttribute?.('data-action');
   const rowId = activeElement?.closest?.(SHARED_SCHEMA_ROW_SELECTOR)?.getAttribute?.('data-row-id');
-  if (!rowId || (!fieldName && actionName !== 'pick-command')) {
+  if (!rowId || (!fieldName && !actionName)) {
     return null;
   }
   return {

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-controller.js
@@ -315,6 +315,16 @@ function createSharedSchemaEditorController({
     semanticValidationTimers.set(rowId, timerId);
   };
 
+  const scheduleFocusSettledSemanticValidationForRow = (rowId) => {
+    clearSemanticValidationTimer(rowId);
+    if (typeof timerApi?.setTimeout !== 'function') {
+      applySemanticValidationForRow(rowId);
+      return;
+    }
+    const timerId = timerApi.setTimeout(() => applySemanticValidationForRow(rowId), 0);
+    semanticValidationTimers.set(rowId, timerId);
+  };
+
   const updateTextElementFromRows = () => {
     const textElement = getTextElement();
     if (textElement) {
@@ -785,7 +795,7 @@ function createSharedSchemaEditorController({
     if (!rowId) {
       return;
     }
-    scheduleSemanticValidationForRow(rowId, { immediate: true });
+    scheduleFocusSettledSemanticValidationForRow(rowId);
   };
 
   const handleClick = async (event) => {

--- a/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-ui.js
+++ b/packages/core-ui/js/gui_components/shared/test-data/schema/shared-schema-editor-ui.js
@@ -88,13 +88,6 @@ function renderSharedSchemaRows({
     rowElem.setAttribute('data-row-id', row.id);
     rowElem.setAttribute('data-row-index', String(index));
     rowElem.innerHTML = `
-                <div class="${SHARED_SCHEMA_ROW_ACTIONS_CLASS}">
-                    <button class="icon-button ${SHARED_SCHEMA_DRAG_HANDLE_CLASS}" type="button" data-action="drag" data-row-id="${row.id}" title="Drag field to reorder" draggable="true" aria-label="Drag field to reorder">${renderIconHtml('grip-vertical')}</button>
-                    <button class="icon-button" type="button" data-action="add" data-row-id="${row.id}" title="Add field" aria-label="Insert field after this row">${renderIconHtml('plus')}</button>
-                    <button class="icon-button" type="button" data-action="remove" data-row-id="${row.id}" title="Remove field" aria-label="Remove field">${renderIconHtml('minus')}</button>
-                    <button class="icon-button" type="button" data-action="up" data-row-id="${row.id}" title="Move up" aria-label="Move up" ${index === 0 ? 'disabled' : ''}>${renderIconHtml('arrow-up')}</button>
-                    <button class="icon-button" type="button" data-action="down" data-row-id="${row.id}" title="Move down" aria-label="Move down" ${index === schemaRows.length - 1 ? 'disabled' : ''}>${renderIconHtml('arrow-down')}</button>
-                </div>
                 <input type="text" data-field="name" class="${hasNameValidationError ? SHARED_SCHEMA_FIELD_INVALID_CLASS : ''}" placeholder="Column Name" aria-label="Column Name" value="${escapeHtml(row.name)}">
                 <select data-field="sourceType" class="${hasCommandValidationError ? SHARED_SCHEMA_FIELD_INVALID_CLASS : ''}" aria-label="Field type">
                     <option value="${SOURCE_TYPE_ENUM}" ${normalisedSourceType === SOURCE_TYPE_ENUM ? 'selected' : ''}>enum</option>
@@ -153,6 +146,13 @@ function renderSharedSchemaRows({
                     ? `<div class="${SHARED_SCHEMA_ROW_VALIDATION_CLASS}" role="status">${escapeHtml(validationMessage)}</div>`
                     : ''
                 }
+                <div class="${SHARED_SCHEMA_ROW_ACTIONS_CLASS}">
+                    <button class="icon-button ${SHARED_SCHEMA_DRAG_HANDLE_CLASS}" type="button" data-action="drag" data-row-id="${row.id}" title="Drag field to reorder" draggable="true" aria-label="Drag field to reorder">${renderIconHtml('grip-vertical')}</button>
+                    <button class="icon-button" type="button" data-action="add" data-row-id="${row.id}" title="Add field" aria-label="Insert field after this row">${renderIconHtml('plus')}</button>
+                    <button class="icon-button" type="button" data-action="remove" data-row-id="${row.id}" title="Remove field" aria-label="Remove field">${renderIconHtml('minus')}</button>
+                    <button class="icon-button" type="button" data-action="up" data-row-id="${row.id}" title="Move up" aria-label="Move up" ${index === 0 ? 'disabled' : ''}>${renderIconHtml('arrow-up')}</button>
+                    <button class="icon-button" type="button" data-action="down" data-row-id="${row.id}" title="Move down" aria-label="Move down" ${index === schemaRows.length - 1 ? 'disabled' : ''}>${renderIconHtml('arrow-down')}</button>
+                </div>
             `;
 
     const schemaHelpElement = rowElem.querySelector('[data-field="faker-doc-link"]');

--- a/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
+++ b/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
@@ -50,8 +50,10 @@ function createFocusedAppTestDataHarness() {
     if (!element) {
       throw new Error('Target input element was not found in focused app test-data harness');
     }
-    await user.click(element);
-    await user.clear(element);
+    element.focus();
+    element.value = '';
+    fireEvent.input(element, { target: { value: '' } });
+    fireEvent.change(element, { target: { value: '' } });
     if (value) {
       if (element.type === 'number' || /[\n\\[\]{}]/.test(value)) {
         element.value = value;
@@ -62,6 +64,9 @@ function createFocusedAppTestDataHarness() {
       }
     }
     element.blur();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
   }
 
   async function setSelectValue(element, value) {

--- a/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
+++ b/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
@@ -90,6 +90,7 @@ function createFocusedAppTestDataHarness() {
     }
     await user.selectOptions(element, value);
     await user.tab();
+    await waitForFocusToLeave(element);
   }
 
   function reset() {

--- a/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
+++ b/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
@@ -46,6 +46,12 @@ function createFocusedAppTestDataHarness() {
     return getPanelRoot()?.querySelector('[data-role="schema-definition-root"]') || null;
   }
 
+  async function waitForFocusToLeave(element) {
+    await waitFor(() => {
+      expect(element.ownerDocument.activeElement).not.toBe(element);
+    });
+  }
+
   async function setInputValue(element, value) {
     if (!element) {
       throw new Error('Target input element was not found in focused app test-data harness');
@@ -60,9 +66,7 @@ function createFocusedAppTestDataHarness() {
         initialSelectionEnd: String(element.value || '').length,
       });
       await user.tab();
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
+      await waitForFocusToLeave(element);
       return;
     }
 
@@ -77,9 +81,7 @@ function createFocusedAppTestDataHarness() {
     }
 
     await user.tab();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await waitForFocusToLeave(element);
   }
 
   async function setSelectValue(element, value) {

--- a/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
+++ b/packages/core-ui/src/tests/interaction/support/focused-app-test-data-harness.js
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor, within } from '@testing-library/dom';
+import { waitFor, within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import RandExp from 'randexp';
 import { Exporter } from '@anywaydata/core/grid/exporter.js';
@@ -50,20 +50,33 @@ function createFocusedAppTestDataHarness() {
     if (!element) {
       throw new Error('Target input element was not found in focused app test-data harness');
     }
-    element.focus();
-    element.value = '';
-    fireEvent.input(element, { target: { value: '' } });
-    fireEvent.change(element, { target: { value: '' } });
-    if (value) {
-      if (element.type === 'number' || /[\n\\[\]{}]/.test(value)) {
-        element.value = value;
-        fireEvent.input(element, { target: { value } });
-        fireEvent.change(element, { target: { value } });
+
+    const nextValue = value === null || value === undefined ? '' : String(value);
+    await user.click(element);
+
+    if (element.type === 'number' && nextValue) {
+      await user.type(element, nextValue, {
+        initialSelectionStart: 0,
+        initialSelectionEnd: String(element.value || '').length,
+      });
+      await user.tab();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      return;
+    }
+
+    await user.clear(element);
+
+    if (nextValue) {
+      if (/[\n\\[\]{}]/.test(nextValue)) {
+        await user.paste(nextValue);
       } else {
-        await user.type(element, value);
+        await user.type(element, nextValue, { skipClick: true });
       }
     }
-    element.blur();
+
+    await user.tab();
     await new Promise((resolve) => {
       setTimeout(resolve, 0);
     });
@@ -73,11 +86,8 @@ function createFocusedAppTestDataHarness() {
     if (!element) {
       throw new Error('Target select element was not found in focused app test-data harness');
     }
-    element.focus();
-    element.value = value;
-    fireEvent.input(element, { target: { value } });
-    fireEvent.change(element, { target: { value } });
-    element.blur();
+    await user.selectOptions(element, value);
+    await user.tab();
   }
 
   function reset() {

--- a/packages/core-ui/src/tests/interaction/support/focused-generator-harness.js
+++ b/packages/core-ui/src/tests/interaction/support/focused-generator-harness.js
@@ -102,6 +102,9 @@ function createFocusedGeneratorHarness() {
     fireEvent.input(element, { target: { value: element.value } });
     fireEvent.change(element, { target: { value: element.value } });
     element.blur();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
   }
 
   function reset() {
@@ -143,7 +146,11 @@ function createFocusedGeneratorHarness() {
     await waitFor(() => expect(getRow(index)).toBeTruthy());
 
     if (row.sourceType === 'faker' || row.sourceType === 'domain') {
-      const commandSelect = getRow(index).querySelector('[data-field="command"]');
+      let commandSelect = null;
+      await waitFor(() => {
+        commandSelect = getRow(index)?.querySelector('[data-field="command"]') || null;
+        expect(commandSelect).toBeTruthy();
+      });
       await user.selectOptions(commandSelect, row.command);
       const paramsInput = within(getRow(index)).getByPlaceholderText('Params e.g. (10)');
       await setInputValue(paramsInput, row.params || '');

--- a/packages/core-ui/src/tests/shared/schema-focus-state.test.js
+++ b/packages/core-ui/src/tests/shared/schema-focus-state.test.js
@@ -1,0 +1,47 @@
+import { JSDOM } from 'jsdom';
+import {
+  captureActiveFieldState,
+  restoreActiveFieldState,
+} from '../../../js/gui_components/shared/test-data/schema/schema-focus-state.js';
+
+describe('schema focus state', () => {
+  let dom;
+
+  afterEach(() => {
+    dom?.window.close();
+  });
+
+  test('captures and restores focused row action buttons after a row render', () => {
+    dom = new JSDOM(`
+      <!doctype html>
+      <html>
+        <body>
+          <div class="shared-schema-row" data-row-id="row-1">
+            <button type="button" data-action="drag">Drag</button>
+          </div>
+        </body>
+      </html>
+    `);
+    const { document } = dom.window;
+
+    document.querySelector('[data-action="drag"]').focus();
+
+    const state = captureActiveFieldState(document);
+    expect(state).toMatchObject({
+      rowId: 'row-1',
+      fieldName: null,
+      actionName: 'drag',
+    });
+
+    document.body.innerHTML = `
+      <div class="shared-schema-row" data-row-id="row-1">
+        <button type="button" data-action="drag">Drag</button>
+      </div>
+    `;
+    const nextDragButton = document.querySelector('[data-action="drag"]');
+
+    restoreActiveFieldState(document, state);
+
+    expect(document.activeElement).toBe(nextDragButton);
+  });
+});

--- a/packages/core-ui/src/tests/shared/schema-focus-state.test.js
+++ b/packages/core-ui/src/tests/shared/schema-focus-state.test.js
@@ -11,37 +11,87 @@ describe('schema focus state', () => {
     dom?.window.close();
   });
 
-  test('captures and restores focused row action buttons after a row render', () => {
+  function renderRowWithActions() {
+    dom.window.document.body.innerHTML = `
+      <div class="shared-schema-row shared-schema-row-invalid" data-row-id="row-1">
+        <input type="text" data-field="name" value="Name">
+        <button type="button" data-action="pick-command">Pick command</button>
+        <div class="shared-schema-row-validation" role="status">invalid row</div>
+        <div class="shared-schema-row-actions">
+          <button type="button" data-action="drag">Drag</button>
+          <button type="button" data-action="add">Add</button>
+          <button type="button" data-action="remove">Remove</button>
+          <button type="button" data-action="up">Up</button>
+          <button type="button" data-action="down">Down</button>
+        </div>
+      </div>
+    `;
+  }
+
+  test.each(['pick-command', 'drag', 'add', 'remove', 'up', 'down'])(
+    'captures and restores focused %s action buttons after a row render',
+    (actionName) => {
+      dom = new JSDOM(`
+        <!doctype html>
+        <html>
+          <body></body>
+        </html>
+      `);
+      const { document } = dom.window;
+
+      renderRowWithActions();
+
+      document.querySelector(`[data-action="${actionName}"]`).focus();
+
+      const state = captureActiveFieldState(document);
+      expect(state).toMatchObject({
+        rowId: 'row-1',
+        fieldName: null,
+        actionName,
+      });
+
+      renderRowWithActions();
+      const nextActionButton = document.querySelector(`[data-action="${actionName}"]`);
+
+      restoreActiveFieldState(document, state);
+
+      expect(document.activeElement).toBe(nextActionButton);
+    }
+  );
+
+  test('captures and restores focused row fields after a row render', () => {
     dom = new JSDOM(`
       <!doctype html>
       <html>
         <body>
-          <div class="shared-schema-row" data-row-id="row-1">
-            <button type="button" data-action="drag">Drag</button>
+          <div class="shared-schema-row shared-schema-row-invalid" data-row-id="row-1">
+            <input type="text" data-field="name" value="Name">
+            <div class="shared-schema-row-validation" role="status">invalid row</div>
           </div>
         </body>
       </html>
     `);
     const { document } = dom.window;
 
-    document.querySelector('[data-action="drag"]').focus();
+    document.querySelector('[data-field="name"]').focus();
 
     const state = captureActiveFieldState(document);
     expect(state).toMatchObject({
       rowId: 'row-1',
-      fieldName: null,
-      actionName: 'drag',
+      fieldName: 'name',
+      actionName: null,
     });
 
     document.body.innerHTML = `
-      <div class="shared-schema-row" data-row-id="row-1">
-        <button type="button" data-action="drag">Drag</button>
+      <div class="shared-schema-row shared-schema-row-invalid" data-row-id="row-1">
+        <input type="text" data-field="name" value="Name">
+        <div class="shared-schema-row-validation" role="status">invalid row</div>
       </div>
     `;
-    const nextDragButton = document.querySelector('[data-action="drag"]');
+    const nextNameInput = document.querySelector('[data-field="name"]');
 
     restoreActiveFieldState(document, state);
 
-    expect(document.activeElement).toBe(nextDragButton);
+    expect(document.activeElement).toBe(nextNameInput);
   });
 });

--- a/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
+++ b/packages/core-ui/src/tests/shared/shared-schema-editor-controller.test.js
@@ -103,6 +103,53 @@ describe('createSharedSchemaEditorController', () => {
     expect(timerApi.clearTimeout).toHaveBeenCalledWith('timer-1');
   });
 
+  test('defers focusout validation until native tab focus can settle', () => {
+    const root = createRoot(dom.window.document);
+    const timerApi = {
+      setTimeout: jest.fn(() => 'focusout-timer'),
+      clearTimeout: jest.fn(),
+    };
+
+    const controller = createSharedSchemaEditorController({
+      documentObj: dom.window.document,
+      rootElement: root,
+      timerApi,
+      createBlankRow: () => ({
+        id: 'row-1',
+        name: '',
+        sourceType: 'literal',
+        command: 'literal',
+        value: '',
+        params: '',
+        semanticValidationIssues: [],
+      }),
+      mapRuleToRow: () => ({
+        id: 'row-1',
+        name: '',
+        sourceType: 'literal',
+        command: 'literal',
+        value: '',
+        params: '',
+        semanticValidationIssues: [],
+      }),
+      schemaTextToDataRules: jest.fn(() => ({ dataRules: [], errors: [] })),
+      dataRulesToSchemaText: jest.fn(() => ''),
+      validateSchemaRows: jest.fn((rows) => ({ rows, errors: [] })),
+      updatePairwiseButtonVisibility: jest.fn(),
+      updateHelpHints: jest.fn(),
+    });
+
+    controller.init();
+    const nameInput = root.querySelector('[data-field="name"]');
+    controller.handleFocusOut({ target: nameInput });
+
+    expect(timerApi.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 0);
+
+    controller.destroy();
+
+    expect(timerApi.clearTimeout).toHaveBeenCalledWith('focusout-timer');
+  });
+
   test('opens the params editor dialog and applies validated params back to the row', async () => {
     const root = createRoot(dom.window.document);
     const controller = createSharedSchemaEditorController({

--- a/packages/core-ui/src/tests/shared/shared-schema-editor-ui.test.js
+++ b/packages/core-ui/src/tests/shared/shared-schema-editor-ui.test.js
@@ -89,6 +89,28 @@ describe('shared schema editor ui', () => {
     expect(shadowSelect.getAttribute('tabindex')).toBe('-1');
   });
 
+  test('orders focusable row controls from editable fields to row actions', () => {
+    renderSharedSchemaRows({
+      documentObj: document,
+      rowsElement,
+      schemaRows: [{ id: '1', name: 'First', sourceType: 'regex', value: '[A-Z]{2}' }],
+      getSchemaHelpData: () => ({
+        show: true,
+        docsUrl: '/docs/regex',
+        title: 'Regex data help',
+        html: '<p>Regex help</p>',
+      }),
+      updateAllPairsButtonVisibility: () => {},
+    });
+
+    const row = rowsElement.querySelector('.shared-schema-row');
+    const focusableOrder = Array.from(row.querySelectorAll('input, select, a, button'))
+      .filter((element) => !element.disabled && !element.hidden && element.tabIndex >= 0)
+      .map((element) => element.getAttribute('data-field') || element.getAttribute('data-action'));
+
+    expect(focusableOrder).toEqual(['name', 'sourceType', 'faker-doc-link', 'value', 'drag', 'add', 'remove']);
+  });
+
   test('hides the shared schema mode help tooltip when present', () => {
     const hide = jest.fn();
     modeHelpIconElement._tippy = { hide };


### PR DESCRIPTION
## Summary

Fixes the generator schema row keyboard tab order so primary editing controls are reached before row action buttons.

- Keeps the visual row-action column on the left while moving row actions after editable controls in DOM/tab order.
- Defers focusout validation until native Tab focus settles, preventing row re-rendering from dropping focus to the page body.
- Restores focus for schema row action buttons after validation re-renders.
- Ignores Codex dev-server log variants with `.codex-dev-web*.log`.

## Fixed Issues

Closes #271
Closes #291

## Validation

- `pnpm run verify:ui`
- `pnpm run verify:local`
- push hook reran the local verification path successfully
- published test environment: https://eviltester.github.io/grid-table-editor/
- publish workflow: https://github.com/eviltester/grid-table-editor/actions/runs/28435458210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in schema rows so Tab follows a consistent, intuitive order through inputs, links, and row actions.
  * Focus restoration after schema row updates is now more reliable.
  * Validation on blur is deferred until focus has settled, reducing premature updates.
* **UI Improvements**
  * Refreshed shared schema row layout using explicit grid placement for clearer control positioning.
* **Tests**
  * Added/expanded coverage for tab order, focus restoration, and deferred blur validation.
* **Documentation**
  * Updated and added blog posts to reflect release workflow and helper/auto-increment capabilities.
* **Chores**
  * Updated log ignore patterns for cleaner local checkouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->