### PR TITLE
Add Excel to Markdown to related tools

### DIFF
--- a/docs-src/docs/050-misc/related_tools.md
+++ b/docs-src/docs/050-misc/related_tools.md
@@ -50,6 +50,7 @@ Other tools that are similar to Any Way Data that might be useful.
 Online Table editors for multiple formats.
 
 - [Ascii Table](https://ozh.github.io/ascii-tables/) - convert tab delimited data to various ASCII and Markdown formats and can prefix programming language comment indicators for pasting into source code.
+- [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert XLSX, XLS, and CSV files to Markdown tables locally in the browser, with worksheet, header, and column-alignment controls.
 - [Table Convert](https://tableconvert.com/) - Convert CSV, Excel, HTML, Markdown, JSON, SQL, Latex, MediaWiki to Markdown, SQL and Latex
 - [Tables Generator](https://www.tablesgenerator.com/) - CSV to Latex, HTML, Text and Markdown tables
 - [Truben Table Editor](https://truben.no/table/) - Interactive table editor convert to Latex, Balsamiq, BBCode, CSV, HTML, JSON, Markdown, Mathematica, Plain Text, reStructuredText, SQL, Wiki.


### PR DESCRIPTION
Summary:
- Adds Excel to Markdown to the Multi Format Tables section of the related tools page.
- Documents support for XLSX, XLS, CSV, worksheet selection, headers, and column alignment.

Disclosure: I built and operate Excel to Markdown.

Link: https://exceltomd.com/excel-to-markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Excel to Markdown to the list of related tools, with a link to exceltomd.com.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->